### PR TITLE
Partially closes #3: integer-simple problems

### DIFF
--- a/NOTES-2012.3.0.0
+++ b/NOTES-2012.3.0.0
@@ -1,0 +1,13 @@
+= Release 2012.3 =
+
+== Changes in Source Control ==
+text 10.2.2.0 -> 10.2.2.2, fixed: integer-simple incompatible with text.
+
+== Changes for Mac ==
+
+== Things to Do ==
+[x] package up doc for website
+[x] upload doc
+
+[x] update timeline in wiki: http://trac.haskell.org/haskell-platform/wiki/ReleaseTimetable
+

--- a/haskell-platform.cabal
+++ b/haskell-platform.cabal
@@ -23,7 +23,7 @@ description:
 
 cabal-version:       >= 1.8
 build-type:          Custom
-tested-with:         GHC ==7.4.1
+tested-with:         GHC ==7.4.2
 
 library
   build-depends:
@@ -73,7 +73,7 @@ library
     regex-posix                 ==0.95.1,
     stm                         ==2.3,
     syb                         ==0.3.6.1,
-    text                        ==0.11.2.0,
+    text                        ==0.11.2.2,
     transformers                ==0.3.0.0,
     xhtml                       ==3000.2.1,
     zlib                        ==0.5.3.3


### PR DESCRIPTION
This change enables Haskell Platform to compile _if_ appropriate flag for text is chosen.
Need to add automatic configuration there later.
