### PR TITLE
Bump parsec to 3.1.3 from 3.1.2

### DIFF
--- a/haskell-platform.cabal
+++ b/haskell-platform.cabal
@@ -65,7 +65,7 @@ library
     network                     ==2.3.0.13,
     OpenGL                      ==2.2.3.1,
     parallel                    ==3.2.0.2,
-    parsec                      ==3.1.2,
+    parsec                      ==3.1.3,
     QuickCheck                  ==2.4.2,
     random                      ==1.0.1.1,
     regex-base                  ==0.93.2,


### PR DESCRIPTION
Parsec 3.1.3 fixed a regression introduced in 3.1.2 related to positions reported by error messages.
