### PR TITLE
Fix readme tarball

### DIFF
--- a/README
+++ b/README
@@ -15,11 +15,11 @@ the platform for use in building OS installer packages.
 
 To boot-strap the build, the current system must have a working GHC installed,
 and cabal with sandbox support installed (generally 1.18.0 or later)[1] You also
-need a GHC bindist that matches the platform[2].
+need a GHC bindist bz2 tarball that matches the platform[2].
 
 Then simply, run this:
 
-   ./platform.sh $PATH_TO_GHC_BINDIST
+   ./platform.sh $PATH_TO_GHC_BINDIST_TARBALL
 
 This will build the hptool itself, and then use that tool to build first the
 platform source tarball, and finally the hermetic build of all the platform


### PR DESCRIPTION
Trying again with something extremely simple, this time hopefully on the right branch:

When I took my first stab at using ./platform.sh, I thought the bin-dist parameter was the path to an installed GHC bindist. After it became clear that it actually needed to be the original tarball, it still didn't work, because I had the `xz` tarball, not the `bz2` tarball. I clarified those points in the README.
