### PR TITLE
platform.sh on Linux attempts to put regDir in /usr/local, which requires root

### DIFF
--- a/hptool/src/OS/Internal.hs
+++ b/hptool/src/OS/Internal.hs
@@ -53,7 +53,7 @@ genericOS BuildConfig{..} = OS{..}
     osPackageTargetDir p = osHpPrefix </> "lib" </> packagePattern p
     osPackageInstallAction p = do
         let confFile = packageTargetConf p
-        let regDir = osHpPrefix </> "etc" </> "registrations"
+        let regDir = targetDir </+> osHpPrefix </> "etc" </> "registrations"
         let regFile = regDir </> show p
         makeDirectory regDir
         hasReg <- doesFileExist confFile


### PR DESCRIPTION
Fixes platform.sh crash on Linux due to attempt to put `regDir` in `/usr/local`, which requires root.
