### PR TITLE
support extracting ghc xz'ed tarballs

### DIFF
--- a/hptool/src/GhcDist.hs
+++ b/hptool/src/GhcDist.hs
@@ -28,8 +28,9 @@ ghcInstall base mfPrefix = do
 
     makeDirectory untarDir
 
+    let extract = if takeExtension tarFile == ".xz" then "-Jxf" else "-jxf"
     command_ [Cwd untarDir]
-        "tar" ["-jxf", tarFile ® untarDir]
+        "tar" [extract, tarFile ® untarDir]
 
     configCmd <- liftIO $ absolutePath $ distDir </> "configure"
     absPrefix <- liftIO $ absolutePath $ prefix


### PR DESCRIPTION
GHC upstream started with 7.8 shipping .tar.xz files as well as .tar.gz.
It would be nice to support those: this change does that.

If a finer case statement is preferred I can rework the patch.
