### PR TITLE
use .cabal-sandbox/bin/hptool

### DIFF
--- a/platform.sh
+++ b/platform.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-HPTOOL=hptool/dist/build/hptool/hptool
+HPTOOL=hptool/.cabal-sandbox/bin/hptool
 
 if [ \! \( -e $HPTOOL -a -x $HPTOOL \) ]
 then


### PR DESCRIPTION
It seems to me that platform.sh should use `.cabal-sandbox/bin/hptool`
rather than `dist/build/hptool/hptool` (I am not entirely clear on 
the relationship between the two to be honest, but it seems `cabal install`
in a sandbox updates directly to `.cabal-sandbox/` not `dist/`, or
am I hitting some cabal-install quirk?)

Anyway without this change rebuilding hptool has no effect from `platform.sh`.
Though I haven't tested this yet from a clean checkout.