### PR TITLE
name source tarball .tar.gz not .tgz

### DIFF
--- a/hptool/src/Main.hs
+++ b/hptool/src/Main.hs
@@ -53,7 +53,7 @@ main = shakeArgsWith opts [] main'
 
     hpRelease = hp2014_1_0_0
     hpFullName = show $ relVersion hpRelease
-    srcTarFile = productDir </> hpFullName <.> "tgz"
+    srcTarFile = productDir </> hpFullName <.> "tar.gz"
 
 
 buildRules :: Release -> FilePath -> BuildConfig -> Rules()


### PR DESCRIPTION
I think it would be better to stick with naming the tarballs `.tar.gz`
rather than `.tgz` unless there is a good workflow reason not to.
