### PR TITLE
use "tar xf" for compression autodetection

### DIFF
--- a/hptool/src/GhcDist.hs
+++ b/hptool/src/GhcDist.hs
@@ -29,7 +29,7 @@ ghcInstall base mfPrefix = do
     makeDirectory untarDir
 
     command_ [Cwd untarDir]
-        "tar" ["-jxf", tarFile ® untarDir]
+        "tar" ["xf", tarFile ® untarDir]
 
     configCmd <- liftIO $ absolutePath $ distDir </> "configure"
     absPrefix <- liftIO $ absolutePath $ prefix


### PR DESCRIPTION
GNU tar 1.15 (2004) and later supports auto-detection of compression.
GHC 7.8 started shipping .tar.xz binary tarballs in addition to .tar.bz2,
so this change should allow using either with hptool and also .gz, etc.
