### PR TITLE
Add verbosity to cabal and ghc-pkg shell-outs

### DIFF
--- a/hptool/src/Target.hs
+++ b/hptool/src/Target.hs
@@ -62,6 +62,7 @@ buildAction buildDir hpRel bc = do
 
         command_ [] "cp" ["-pR", sourceDir, buildDir]
 
+        ghcPkgVerbosity <- shakeToGhcPkgVerbosity
         removeDirectoryRecursive depsDB
         localCommand' [] "ghc-pkg" ["init", depsDB]
         forM_ deps $ \d -> do
@@ -71,10 +72,13 @@ buildAction buildDir hpRel bc = do
                 localCommand' [] "ghc-pkg"
                     [ "register"
                     , "--package-db=" ++ depsDB
+                    , "--verbose=" ++ show ghcPkgVerbosity
                     , inplace
                     ]
 
-        let cabal c as = localCommand' [Cwd buildDir] "cabal" $ c : as
+        cabalVerbosity <- shakeToCabalVerbosity
+        let cabal c as = localCommand' [Cwd buildDir] "cabal" $
+                             c : ("--verbose=" ++ show cabalVerbosity) : as
         when (not isAlexOrHappy) $
             cabal "clean" []  -- This is a hack to handle when packages, other
                               -- than alex or happy themselves, have outdated

--- a/hptool/src/Utils.hs
+++ b/hptool/src/Utils.hs
@@ -2,7 +2,8 @@ module Utils where
 
 import Data.Maybe (listToMaybe)
 import Data.Version (Version, parseVersion)
-import Development.Shake (Action, command_, liftIO, writeFileChanged)
+import Development.Shake (Action, command_, getVerbosity, liftIO,
+                          Verbosity(..), writeFileChanged)
 import Development.Shake.FilePath
 import Text.ParserCombinators.ReadP (readP_to_S)
 import System.Directory (createDirectoryIfMissing, getCurrentDirectory)
@@ -76,3 +77,26 @@ makeDirectory fp = liftIO $ createDirectoryIfMissing True fp
 writeFileLinesChanged :: FilePath -> [String] -> Action ()
 writeFileLinesChanged fp = writeFileChanged fp . unlines
 
+-- ghc-pkg command line verbosity ranges from 0..2, with 1 the default
+shakeToGhcPkgVerbosity :: Action Int
+shakeToGhcPkgVerbosity = do
+    sV <- getVerbosity
+    return $ case sV of
+                 Silent     -> 0
+                 Quiet      -> 0
+                 Normal     -> 1
+                 Loud       -> 1
+                 Chatty     -> 2
+                 Diagnostic -> 2
+
+-- cabal command line verbosity ranges from 0..3, with 1 the default
+shakeToCabalVerbosity :: Action Int
+shakeToCabalVerbosity = do
+    sV <- getVerbosity
+    return $ case sV of
+                 Silent     -> 0
+                 Quiet      -> 0
+                 Normal     -> 1
+                 Loud       -> 2
+                 Chatty     -> 3
+                 Diagnostic -> 3


### PR DESCRIPTION
Since hptool uses the shake package, it can take advantage of shake's
verbosity using "--verbose" on the hptool command line (up to 3
"--verbose" switches can be used to increase shake's verbosity, but
note that the third one is for actual Shake-debugging).

A simple mapping between Development.Shake.Verbosity (from
Development.Shake.getVerbosity) to the verbosity values (integers) of
both the cabal and ghc-pkg executables is used, allowing two "--verbose"
command-line switches to get the maximum verbosity from both, as well as
the maximum useful level from shake (for shake-library users).

A 1:1 mapping is not possible from shake to either cabal or
ghc-pkg, so what is included here has some arbitrariness which may need
slight refinement if experience shows the desired verbosity of either of
those external tools is not convenient--e.g., does just one "--verbose"
dial all 3 generators (shake, cabal, ghk-pkg) down enough, etc.

Note there are some shell-outs not changed in this commit:  a couple
capture and parse stdout, so adding verbosity to those invocation would
need some additional work not contemplated here; a couple of other cabal
shell-outs were not a source of debugging trouble at present.
