### PR TITLE
Readme tweaks for #98 and #107

### DIFF
--- a/README
+++ b/README
@@ -14,8 +14,9 @@ haskell-platform source tarball, and can build a complete, hermetic build of
 the platform for use in building OS installer packages.
 
 To boot-strap the build, the current system must have a working GHC installed,
-and cabal with sandbox support installed (generally 1.18.0 or later)[1] You also
-need a GHC bindist bz2 tarball that matches the platform[2].
+and cabal with sandbox support installed (generally 1.18.0 or later)[1], and an
+HsColour executable must be in your PATH (current recommended version is
+1.20.3). You also need a GHC bindist tarball that matches the platform[2].
 
 Then simply, run this:
 


### PR DESCRIPTION
In the README, adds the existence of an HsColour executable as part of the boot-strap requirements to resolve #98, and removes the requirement of the bz2 tarball due to #107.
