### PR TITLE
Get GHC tarball from c.h.o. for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: haskell
 ghc: 7.6
-install: ./travis-setup.sh
+install: ./travis-setup.sh ghc-7.8.2-x86_64-unknown-linux-deb7.tar.xz
 script: ./platform.sh ghc-7.8.2-x86_64-unknown-linux-deb7.tar.xz

--- a/travis-setup.sh
+++ b/travis-setup.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-GHC_VER=7.8.2
-GHC_TARBALL=ghc-7.8.2-x86_64-unknown-linux-deb7.tar.xz
+GHC_TARBALL="$1"
 
 set -ev
 
@@ -14,4 +13,4 @@ sudo cp .cabal-sandbox/bin/HsColour /usr/local/bin/
 popd
 
 # Get GHC bin tarball
-wget http://www.haskell.org/ghc/dist/$GHC_VER/$GHC_TARBALL
+wget http://projects.haskell.org/haskell-platform/$GHC_TARBALL


### PR DESCRIPTION
Travis currently downloads the GHC binary tarball from the regular GHC download site for every single build. That will add unneeded load to the GHC site, and also skew their download statistics.

I copied the tarball to the haskell-platform site on c.h.o (currently unused) and configured travis to download the tarball from there instead.
