### PR TITLE
Fix localCommand for Windows platform

### DIFF
--- a/hptool/src/GhcDist.hs
+++ b/hptool/src/GhcDist.hs
@@ -74,7 +74,7 @@ localCommand opts cmdName args = do
     let localCmd = absLocalBin </> cmdName
     useLocalCmd <- if '/' `elem` cmdName
                         then return False
-                        else doesFileExist localCmd
+                        else doesFileExist $ localCmd <.> exe
     command (localPath : opts) (if useLocalCmd then localCmd else cmdName) args
 
 localCommand' :: [CmdOption] -> String -> [String] -> Action ()


### PR DESCRIPTION
The 'localCommand' function looks for an executable by looking for a file
of the exact command name, which usually will fail on Windows platforms
since the filenames for executables end with ".exe".  This change uses
Development.Shake.FilePath support to include the ".exe" when appropriate.

This change should be transparent for non-Windows platforms, and is
necessary, but not sufficient, for the HP build on Windows.
