### PR TITLE
Remove Windows-specific Data-files section

### DIFF
--- a/hptool/hptool.cabal
+++ b/hptool/hptool.cabal
@@ -9,14 +9,6 @@ Synopsis:        Haskell Platform Utility
 
 Data-files:
   templates/*.cabal.mu
-  if os(windows)
-    Data-files:
-      os-extras/win/CreateInternetShortcut.nsh
-      os-extras/win/EnvVarUpdate.nsh
-      os-extras/win/LICENSE
-      os-extras/win/icons/*
-      os-extras/win/templates/*.mu
-      os-extras/win/welcome.bmp
 
 Executable hptool
   Main-is: Main.hs


### PR DESCRIPTION
This section is tripping up the other platforms while
building the build-source target; this section is not
used for the Windows build.  If there is some reason for
the hptool source tarball for Windows at some point,
we can revisit what has to be included here.
