### PR TITLE
Make platform.sh sensitive to all failures

### DIFF
--- a/platform.sh
+++ b/platform.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 HPTOOL=hptool/dist/build/hptool/hptool
 
 if [ \! \( -e $HPTOOL -a -x $HPTOOL \) ]


### PR DESCRIPTION
Without "set -e", if you run this script using older cabal, it might continue running after failing to create a sandbox, which would install hptool's dependencies into user's local cabal installation.
