### PR TITLE
Change `tar xvf` to `tar xzf`

### DIFF
--- a/website/linux.html.mu
+++ b/website/linux.html.mu
@@ -85,7 +85,7 @@ style systems:</p>
 
 <p>To install this, run:</p>
 <pre><code>    cd /
-    sudo tar xvf ...downloaded-tarfile...
+    sudo tar xzf ...downloaded-tarfile...
     sudo /usr/local/haskell/ghc-{{ghcVersion}}-x86_64/bin/activate-hs</code></pre>
 
 <p>Notes:</p>


### PR DESCRIPTION
Since the downloaded file is a tar.gz, this is necessary. The 'v' was probably a typo.