### PR TITLE
Path separator clean-ups for Windows; log a warning when

### DIFF
--- a/hptool/src/LocalCommand.hs
+++ b/hptool/src/LocalCommand.hs
@@ -6,13 +6,13 @@ module LocalCommand
 import Data.List (intercalate)
 import Development.Shake (Action, CmdOption(..), CmdResult, command,
                           doesFileExist, liftIO, need)
-import Development.Shake.FilePath ( (</>), (<.>), exe, searchPathSeparator )
+import Development.Shake.FilePath ( (</>), (<.>), exe, searchPathSeparator,
+                                    isPathSeparator )
 import System.Environment (getEnvironment)
 
 import Dirs
 import Paths
 import Utils
-
 
 -- | Run a command, but favor the local GHC instalation.
 -- Note that 'command' ends up calling 'createProcess', which in turn in this
@@ -29,7 +29,7 @@ localCommand opts cmdName args = do
     absLocalBin <- liftIO $ absolutePath localBin
     localPath <- addPath' [absLocalBin] []
     let localCmd = absLocalBin </> cmdName
-    useLocalCmd <- if '/' `elem` cmdName
+    useLocalCmd <- if any isPathSeparator cmdName
                         then return False
                         else doesFileExist $ localCmd <.> exe
     command (localPath : opts) (if useLocalCmd then localCmd else cmdName) args


### PR DESCRIPTION
Path separator clean-ups for Windows; log a warning when
removing a non-empty directory;

* hptool/src/Dirs.hs
  * In the (*/>) function, use the removeDirectoryRecursive
    function from Util.hs rather than repeat the exact code
    (plus, we can do the warning, if needed, about deleting
    non-empty dirs, in one place)
  * Make 'markerToDir' insensitive to path separator char
* hptool/src/LocalCommand.hs
  * Make 'localCommand' insensitive to path separator char
* hptool/src/Utils.hs
  * Make 'relativeToDir' insensitive to path separator char
  * Add a warning message when recursively removing a
    non-empty directory (which is sometimes legit, e.g., if
    re-starting a failed build, but other times it can
    indicate an incorrect rule/dependency, which can
    otherwise be very hard to track down (because the files
    you thought should have been there were deleted at some
    point)
  * Change the verbosity mapping in 'shakeToGhcPkgVerbosity'
    so that "one louder" shake verbosity ("Chatty" is really
    needed for trying to figure out dependency and rule
    problems) does not cause cabal (and hence ghc) to become
    deafening with ghc's most inner thoughts