### PR TITLE
Fix GhcDist.hs Shake dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: haskell
 ghc: 7.6
 install: ./travis-setup.sh ghc-7.8.3-x86_64-unknown-linux-deb7.tar.xz
 script: ./platform.sh ghc-7.8.3-x86_64-unknown-linux-deb7.tar.xz
+sudo: true

--- a/hptool/hptool.cabal
+++ b/hptool/hptool.cabal
@@ -51,7 +51,7 @@ Executable hptool
     containers,
     directory,
     hastache >=0.6.0,
-    shake,
+    shake < 0.15,
     split,
     text,
     transformers

--- a/hptool/src/Templates.hs
+++ b/hptool/src/Templates.hs
@@ -74,7 +74,7 @@ expandRelease :: (Monad m) => Release -> MuContext m
 expandRelease rel = mkStrContext ex
   where
     ex "hpVersion" = MuVariable . showVersion . hpVersion . relVersion $ rel
-    ex "ghcVersion" = case pkgsThat [isGhc, not . isLib] of
+    ex "ghcVersion" = case pkgsThat [isGhc, not . isLib, not . isTool] of
         [] -> error "No ghc version spec'd in release."
         [ghcPkg] -> MuVariable . showVersion . pkgVersion $ ghcPkg
         _ -> error "More than one ghc version spec'd in release."


### PR DESCRIPTION
The main change being pushed addresses issue #173 by requiring a version of Shake preceding the changes that break haskell-platform.  In order to test that with Travis CI, though, I also had to pull in 9265be27c6de94f5c2ad450de5c0ec1c5ef1eff8 from the `pre-release` branch and edit the `.travis.yml` file to state that the build setup (specifically, `travis-setup.sh`) needs to run `sudo`.  The result works for `master` but introduces some new dependency-related problems when I tried it with `pre-release`.