### PR TITLE
Factor out templates and add other download options

### DIFF
--- a/hptool/src/Website.hs
+++ b/hptool/src/Website.hs
@@ -23,9 +23,13 @@ websiteRules templateSite = do
     websiteDir %/> \dst -> do
         bcCtx <- buildConfigContext
         let rlsCtx = releasesCtx
-            ctx = ctxConcat [rlsCtx, historyCtx, bcCtx, errorCtx]
+            ctx = ctxConcat [rlsCtx, historyCtx, bcCtx, siteUrlsCtx, errorCtx]
         copyExpandedDir ctx templateSite dst
 
+siteUrlsCtx :: (Monad m) => MuContext m
+siteUrlsCtx = assocListContext
+    [ ("haskellOrgRootUrl", "/")      -- url to use to refer to http://haskell.org/
+    ]
 
 fileCtx :: (Monad m) => FileInfo -> MuContext m
 fileCtx (dist, url, mHash) = mkStrContext ctx

--- a/hptool/src/Website.hs
+++ b/hptool/src/Website.hs
@@ -26,6 +26,10 @@ websiteRules templateSite = do
             ctx = ctxConcat [rlsCtx, historyCtx, bcCtx, siteUrlsCtx, errorCtx]
         copyExpandedDir ctx templateSite dst
 
+downloadRoot :: String
+--downloadRoot = "/platform"                     -- For deployment
+downloadRoot = "https://haskell.org/platform/"   -- For testing
+
 siteUrlsCtx :: (Monad m) => MuContext m
 siteUrlsCtx = assocListContext
     [ ("haskellOrgRootUrl", "/")      -- url to use to refer to http://haskell.org/
@@ -35,7 +39,7 @@ fileCtx :: (Monad m) => FileInfo -> MuContext m
 fileCtx (dist, url, mHash) = mkStrContext ctx
   where
     ctx "osNameAndArch" = MuVariable $ distName dist
-    ctx "url" = MuVariable url
+    ctx "url" = MuVariable $ downloadRoot++url
     ctx "mHash" = maybe (MuBool False) MuVariable mHash
     ctx "archBits"
       | DistBinary _ arch <- dist = MuVariable $ archBits arch

--- a/website/contents.html.mu
+++ b/website/contents.html.mu
@@ -11,24 +11,7 @@
     <body class="page-home">
         <div class="wrap">
             <div class="template">
-                <nav class="navbar navbar-default">
-                    <div class="container">
-                        <div class="navbar-header">
-                            <a class="navbar-brand" href="/">
-                                <span class="logo">&#xe600;</span>
-                                Haskell
-                            </a>
-                        </div>
-                        <div class="collapse navbar-collapse">
-                            <ul class="nav navbar-nav">
-                                <li><a href="#">Downloads</a></li>
-                                <li><a href="#">Community</a></li>
-                                <li><a href="#">Documentation</a></li>
-                                <li><a href="#">Learn</a></li>
-                            </ul>
-                        </div>
-                    </div>
-                </nav>
+                {{> navbar }}
 
                 <div class="header">
                     <div class="container">

--- a/website/contents.html.mu
+++ b/website/contents.html.mu
@@ -1,21 +1,12 @@
 <!DOCTYPE html> <!-- -*- mode: web-mode; engine: ctemplate -*- -->
 <html>
     <head>
-        <meta charset="utf-8">
-        <title>Haskell Platform - Included Packages</title>
-        <script src="js/jquery-1.11.1.min.js"></script>
-        <script src="js/contents.js"></script>
-
-        <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-        <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
-        <link rel="stylesheet" type="text/css" href="stylesheets/fonts/Haskell/style.css">
-        <link rel="stylesheet" type="text/css" href="stylesheets/hl.css">
+        {{> head }}
         <link rel="stylesheet" type="text/css" href="stylesheets/contents.css">
-        <link href="https://fonts.googleapis.com/css?family=Open+Sans" type="text/css" rel="stylesheet">
 
-        <link rel="icon" type="image/png" href="img/favicon.png">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="Haskell Platform is a Haskell distribution with batteries included">
+        <script src="js/contents.js"></script>
+        <title>Haskell Platform - Included Packages</title>
     </head>
     <body class="page-home">
         <div class="wrap">

--- a/website/contents.html.mu
+++ b/website/contents.html.mu
@@ -83,20 +83,6 @@
             </div>
         </div>
 
-        <div class="footer">
-            <div class="container">
-                <p>
-                    <span class="item">© 2014–2015 haskell.org</span>
-                    <span class="item footer-contribute">
-                        Got changes to contribute?
-                        <a href="https://github.com/haskell-infra/hl"> Fork or comment on Github</a>
-                    </span>
-                    <span class="pull-right">
-                        <span>Proudly hosted by </span>
-                        <a href="https://www.rackspace.com/"><img src="/static/img/rackspace.svg?etag=J84VdDuP" alt="rackspace" height="20" width="20"></a>
-                    </span>
-                </p>
-            </div>
-        </div>
+        {{> footer }}
     </body>
 </html>

--- a/website/download.html.mu
+++ b/website/download.html.mu
@@ -11,24 +11,7 @@
     <body class="page-home">
         <div class="wrap">
             <div class="template">
-                <nav class="navbar navbar-default">
-                    <div class="container">
-                        <div class="navbar-header">
-                            <a class="navbar-brand" href="/">
-                                <span class="logo">&#xe600;</span>
-                                Haskell
-                            </a>
-                        </div>
-                        <div class="collapse navbar-collapse">
-                            <ul class="nav navbar-nav">
-                                <li class="active"><a href="#">Downloads</a></li>
-                                <li><a href="#">Community</a></li>
-                                <li><a href="#">Documentation</a></li>
-                                <li><a href="#">Learn</a></li>
-                            </ul>
-                        </div>
-                    </div>
-                </nav>
+                {{> navbar }}
 
                 <div class="header">
                     <div class="container">

--- a/website/download.html.mu
+++ b/website/download.html.mu
@@ -56,6 +56,13 @@
                                     <h1 style="width: 50%;">Download Haskell Platform</h1>
                                 </a>
                             </div>
+                            <div class="span4 col-md-4 other-ways">
+                                <h1>Libraries</h1>
+                                <p>Haskell has a vibrant community and a rich
+                                collection of packages ripe for the picking on
+                                <a href="http://hackage.haskell.org/">Hackage</a>,
+                                the Haskell package database.</p>
+                            </div>
                             <div class="span4 col-md-4 other-ways vrule">
                                 <h1>Other ways to install</h1>
                                 <p>While the Haskell Platform is the recommended
@@ -66,13 +73,6 @@
                                     <li><a href="https://www.haskell.org/downloads/osx">OS X</a></li>
                                     <li><a href="https://www.haskell.org/downloads/linux">Linux</a></li>
                                 </ul>
-                            </div>
-                            <div class="span4 col-md-4 other-ways">
-                                <h1>Libraries</h1>
-                                <p>Haskell has a vibrant community and a rich
-                                collection of packages ripe for the picking on
-                                <a href="http://hackage.haskell.org/">Hackage</a>,
-                                the Haskell package database.</p>
                             </div>
                         </div>
                     </div>

--- a/website/download.html.mu
+++ b/website/download.html.mu
@@ -71,8 +71,41 @@
                     </div>
                 </div>
 
+                <div class="download-options">
+                    <div class="container">
+                        <div class="row">
+                            <div class="span4 col-md-4 vrule get-hp">
+                                <a href="#get-started">
+                                    <div style="width: 50%; font-size: 100px; float:right; ">
+                                        <i class="fa fa-arrow-down"></i>
+                                    </div>
+                                    <h1 style="width: 50%;">Download Haskell Platform</h1>
+                                </a>
+                            </div>
+                            <div class="span4 col-md-4 other-ways vrule">
+                                <h1>Other ways to install</h1>
+                                <p>While the Haskell Platform is the recommended
+                                way to get a Haskell environment, there are also
+                                other options</p>
+                                <ul>
+                                    <li><a href="#">Windows</a></li>
+                                    <li><a href="#">OS X</a></li>
+                                    <li><a href="#">Linux</a></li>
+                                </ul>
+                            </div>
+                            <div class="span4 col-md-4 other-ways">
+                                <h1>Libraries</h1>
+                                <p>Haskell has a vibrant community and a rich
+                                collection of packages ripe for the picking on
+                                <a href="http://hackage.haskell.org/">Hackage</a>,
+                                the Haskell package database.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <div class="container">
-                    <h2>Let's get started</h2>
+                    <h2 id="get-started">Let's get started</h2>
                 </div>
 
                 <div class="container found-user-platform" >
@@ -187,7 +220,8 @@
                         <div class="content">
                             <p>
                                 The latest version of the Haskell Platform for Windows is
-                                <strong>{{hpVersion}}</strong>.</p>
+                                <strong>{{hpVersion}}</strong>.
+                            </p>
                             <p> To get started perform these steps,</p>
 
                             <ol class="install-steps">

--- a/website/download.html.mu
+++ b/website/download.html.mu
@@ -1,21 +1,12 @@
 <!DOCTYPE html> <!-- -*- mode: web-mode; engine: ctemplate -*- -->
 <html>
     <head>
-        <meta charset="utf-8">
-        <title>Download Haskell Platform</title>
-        <script src="js/jquery-1.11.1.min.js"></script>
-        <script src="js/download.js"></script>
-
-        <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-        <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
-        <link rel="stylesheet" type="text/css" href="stylesheets/fonts/Haskell/style.css">
-        <link rel="stylesheet" type="text/css" href="stylesheets/hl.css">
+        {{> head }}
         <link rel="stylesheet" type="text/css" href="stylesheets/download.css">
-        <link href="https://fonts.googleapis.com/css?family=Open+Sans" type="text/css" rel="stylesheet">
 
-        <link rel="icon" type="image/png" href="img/favicon.png">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="Haskell Platform is a Haskell distribution with batteries included">
+        <script src="js/download.js"></script>
+        <title>Download Haskell Platform</title>
     </head>
     <body class="page-home">
         <div class="wrap">

--- a/website/download.html.mu
+++ b/website/download.html.mu
@@ -62,9 +62,9 @@
                                 way to get a Haskell environment, there are also
                                 other options</p>
                                 <ul>
-                                    <li><a href="#">Windows</a></li>
-                                    <li><a href="#">OS X</a></li>
-                                    <li><a href="#">Linux</a></li>
+                                    <li><a href="https://www.haskell.org/downloads/windows">Windows</a></li>
+                                    <li><a href="https://www.haskell.org/downloads/osx">OS X</a></li>
+                                    <li><a href="https://www.haskell.org/downloads/linux">Linux</a></li>
                                 </ul>
                             </div>
                             <div class="span4 col-md-4 other-ways">

--- a/website/download.html.mu
+++ b/website/download.html.mu
@@ -444,20 +444,6 @@ $ sudo emerge haskell-platform</pre>
         <!-- a bit of whitespace before the footer -->
         <div style="height: 100px;"></div>
 
-        <div class="footer">
-            <div class="container">
-                <p>
-                    <span class="item">© 2014–2015 haskell.org</span>
-                    <span class="item footer-contribute">
-                        Got changes to contribute?
-                        <a href="https://github.com/haskell-infra/hl"> Fork or comment on Github</a>
-                    </span>
-                    <span class="pull-right">
-                        <span>Proudly hosted by </span>
-                        <a href="https://www.rackspace.com/"><img src="/static/img/rackspace.svg?etag=J84VdDuP" alt="rackspace" height="20" width="20"></a>
-                    </span>
-                </p>
-            </div>
-        </div>
+        {{> footer }}
     </body>
 </html>

--- a/website/stylesheets/download.css
+++ b/website/stylesheets/download.css
@@ -312,3 +312,40 @@ body:not(.js) .downloads-platform .content {max-height: 9000px;}
 .expander img.expand-3 {top: 16px;}
 .expander:hover img.expand-2 {transform: translateY(5px);}
 .expander:hover img.expand-3 {transform: translateY(10px);}
+
+
+.download-options {
+    padding-top: 40px;
+    background-color: #eee;
+    padding-bottom: 20px;
+}
+
+.download-options .span4 {
+    min-height: 150px;
+}
+
+.download-options .vrule {
+    border-right: 1px solid #ddd;
+}
+
+.download-options .get-hp a {
+    color: #000;
+}
+
+.download-options .other-ways h1 {
+    font-size: 24px;
+    text-align: center;
+}
+
+.download-options .other-ways ul {
+    padding: 0;
+    text-align: center;
+}
+
+.download-options .other-ways ul li {
+    list-style: none;
+    display: inline-block;
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-top: 20px;
+}

--- a/website/templates/footer.mu
+++ b/website/templates/footer.mu
@@ -1,0 +1,15 @@
+<div class="footer">
+    <div class="container">
+        <p>
+            <span class="item">© 2014–2015 haskell.org</span>
+            <span class="item footer-contribute">
+                Got changes to contribute?
+                <a href="https://github.com/haskell-infra/hl"> Fork or comment on Github</a>
+            </span>
+            <span class="pull-right">
+                <span>Proudly hosted by </span>
+                <a href="https://www.rackspace.com/"><img src="/static/img/rackspace.svg?etag=J84VdDuP" alt="rackspace" height="20" width="20"></a>
+            </span>
+        </p>
+    </div>
+</div>

--- a/website/templates/head.mu
+++ b/website/templates/head.mu
@@ -1,0 +1,11 @@
+<meta charset="utf-8">
+<script src="js/jquery-1.11.1.min.js"></script>
+
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+<link rel="stylesheet" type="text/css" href="stylesheets/fonts/Haskell/style.css">
+<link rel="stylesheet" type="text/css" href="stylesheets/hl.css">
+<link href="https://fonts.googleapis.com/css?family=Open+Sans" type="text/css" rel="stylesheet">
+
+<link rel="icon" type="image/png" href="img/favicon.png">
+<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/website/templates/navbar.mu
+++ b/website/templates/navbar.mu
@@ -1,17 +1,17 @@
 <nav class="navbar navbar-default">
     <div class="container">
         <div class="navbar-header">
-            <a class="navbar-brand" href="/">
+            <a class="navbar-brand" href="{{haskellOrgRootUrl}}">
                 <span class="logo">&#xe600;</span>
                 Haskell
             </a>
         </div>
         <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav">
-                <li><a href="#">Downloads</a></li>
-                <li><a href="#">Community</a></li>
-                <li><a href="#">Documentation</a></li>
-                <li><a href="#">Learn</a></li>
+                <li><a href="{{haskellOrgRootUrl}}downloads">Downloads</a></li>
+                <li><a href="{{haskellOrgRootUrl}}community">Community</a></li>
+                <li><a href="{{haskellOrgRootUrl}}documentation">Documentation</a></li>
+                <li><a href="{{haskellOrgRootUrl}}news">Learn</a></li>
             </ul>
         </div>
     </div>

--- a/website/templates/navbar.mu
+++ b/website/templates/navbar.mu
@@ -1,0 +1,19 @@
+<nav class="navbar navbar-default">
+    <div class="container">
+        <div class="navbar-header">
+            <a class="navbar-brand" href="/">
+                <span class="logo">&#xe600;</span>
+                Haskell
+            </a>
+        </div>
+        <div class="collapse navbar-collapse">
+            <ul class="nav navbar-nav">
+                <li><a href="#">Downloads</a></li>
+                <li><a href="#">Community</a></li>
+                <li><a href="#">Documentation</a></li>
+                <li><a href="#">Learn</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+


### PR DESCRIPTION
This factors out the header, footer, and navbar into hastache templates.

It also adds copy to the download page describing the other download options besides the Platform.