### PR TITLE
Cleaning up some (Windows) HP 7.10.2 changes

### DIFF
--- a/hptool/os-extras/win/templates/Nsisfile.nsi.mu
+++ b/hptool/os-extras/win/templates/Nsisfile.nsi.mu
@@ -289,6 +289,8 @@ Section "Store GHC's location in registry" SecGHCLoc
   WriteRegStr HKCU "Software\Haskell\GHC\ghc-${GHC_VERSION}" "InstallDir" "$INSTDIR"
   WriteRegStr HKCU "Software\Haskell\GHC" "InstallDir" "$INSTDIR"
 
+  WriteRegStr HKCU "Software\Haskell\WinGHCi 1.0.6" "WorkingDir" "$INSTDIR\winghci"
+
 SectionEnd
 
 Section "Create uninstaller" SecAddRem
@@ -397,6 +399,8 @@ Section "Uninstall"
 
   DeleteRegKey HKCU "Software\Haskell\GHC\ghc-${GHC_VERSION}"
   DeleteRegKey HKCU "Software\Haskell\GHC"
+  ; remove WorkingDir but keep any user customizations for winGHCi
+  DeleteRegValue HKCU "Software\Haskell\WinGHCi 1.0.6" "WorkingDir"
   DeleteRegKey HKLM "${PRODUCT_DIR_REG_KEY}"
   DeleteRegKey /IfEmpty HKCU Software\Haskell
   DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\HaskellPlatform-${PLATFORM_VERSION}"

--- a/hptool/src/GhcDist.hs
+++ b/hptool/src/GhcDist.hs
@@ -39,7 +39,7 @@ cppCommandFlags cpp = case cpp of
 
 
 ghcInstall :: GhcInstall ->
-              FilePath -> Maybe (BuildConfig -> FilePath) -> Action FilePath
+              FilePath -> Maybe (BuildConfig -> FilePath) -> Action (Maybe FilePath)
 ghcInstall postUntarAction base mfPrefix = do
     tarFile <- askGhcBinDistTarFile
     conf <- askBuildConfig
@@ -74,7 +74,7 @@ ghcInstallConfigure base mfPrefix conf distDir = do
     Just cppCommand <- getCppCommand settings settingsFile
     writeSettings settingsFile (updateCppFlags cppCommand settings)
 
-    return destDir
+    return . Just $ destDir
   where
     layout Nothing = (base, base)
     layout (Just p) = (p, base </+> p)
@@ -113,7 +113,7 @@ ghcDistRules = do
         ghcInstall postUntar ghcLocalDir Nothing >> return ()
     ghcVirtualTarget ~/> do
         postUntar <- osGhcTargetInstall . osFromConfig <$> askBuildConfig
-        ghcInstall postUntar targetDir (Just targetPrefix) >>= return . Just
+        ghcInstall postUntar targetDir (Just targetPrefix)
   where
     targetPrefix = osGhcPrefix . osFromConfig
 

--- a/hptool/src/Main.hs
+++ b/hptool/src/Main.hs
@@ -102,7 +102,7 @@ whatIsIncluded = map concat . map includeToString . relIncludes where
 buildRules :: Release -> FilePath -> BuildConfig -> Rules()
 buildRules hpRelease srcTarFile bc = do
     "build-source" ~> need [srcTarFile]
-    "build-target" ~> need [targetDir]
+    "build-target" ~> need [phonyTargetDir]
     "build-product" ~> need [osProduct]
     "build-local" ~> need [dir ghcLocalDir]
     "build-website" ~> need [dir websiteDir]

--- a/hptool/src/OS/Internal.hs
+++ b/hptool/src/OS/Internal.hs
@@ -124,7 +124,7 @@ genericOS BuildConfig{..} = OS{..}
     osProduct = productDir </> "generic.tar.gz"
     osRules _hpRelease _bc =
         osProduct %> \out -> do
-            need [targetDir, vdir ghcVirtualTarget]
+            need [phonyTargetDir, vdir ghcVirtualTarget]
             command_ [Cwd buildRoot]
                 "tar" ["czf", out ® buildRoot, targetDir ® buildRoot]
 

--- a/hptool/src/OS/Mac.hs
+++ b/hptool/src/OS/Mac.hs
@@ -136,7 +136,7 @@ macOsFromConfig BuildConfig{..} = OS{..}
                 ]
 
         hpPkgFile %> \out -> do
-            need [targetDir, dir extrasDir]  -- FIXME(mzero): could be more specific
+            need [phonyTargetDir, dir extrasDir]  -- FIXME(mzero): could be more specific
             command_ []
                 "pkgbuild"
                 [ "--identifier", "org.haskell.HaskellPlatform.Libraries."

--- a/hptool/src/OS/Posix.hs
+++ b/hptool/src/OS/Posix.hs
@@ -96,7 +96,7 @@ posixOS BuildConfig{..} = OS{..}
                 ]
 
         usrLocalTar %> \out -> do
-            need [targetDir, vdir ghcVirtualTarget]
+            need [phonyTargetDir, vdir ghcVirtualTarget]
             command_ [Cwd targetDir]
                 "tar" ["czf", out ® targetDir, hpTargetDir ® targetDir]
 

--- a/hptool/src/OS/Win.hs
+++ b/hptool/src/OS/Win.hs
@@ -87,10 +87,7 @@ winOsFromConfig BuildConfig{..} = os
     whenM :: (Monad m) => m Bool -> m () -> m ()
     whenM mp m = mp >>= \p -> when p m
 
-    osTargetAction = do
-        -- Now, targetDir is actually ready to snapshot (we skipped doing
-        -- this in osGhcTargetInstall).
-        void $ getDirectoryFiles "" [targetDir ++ "//*"]
+    osTargetAction = return ()
 
     osGhcDbDir = winGhcPackageDbDir
 
@@ -128,10 +125,15 @@ winOsFromConfig BuildConfig{..} = os
         winRules
 
         osProduct %> \_ -> do
-            need $ [dir ghcLocalDir, targetDir, vdir ghcVirtualTarget]
-                   ++ winNeeds
+            need $ [dir ghcLocalDir, phonyTargetDir, vdir ghcVirtualTarget]
 
             copyWinTargetExtras bc
+
+            -- Now, targetDir is actually ready to snapshot (we skipped doing
+            -- this in osGhcTargetInstall).
+            void $ getDirectoryFiles "" [targetDir ++ "//*"]
+
+            need winNeeds
 
             -- Now, it is time to make sure there are no problems with the
             -- conf files copied to

--- a/hptool/src/OS/Win.hs
+++ b/hptool/src/OS/Win.hs
@@ -45,10 +45,12 @@ winOsFromConfig BuildConfig{..} = os
         -- dependencies on the contents of winGhcTargetDir won't account
         -- for the HP pieces.  Also, for Windows, the ghc-bindist/local and
         -- the GHC installed into the targetDir should be identical.
-        -- osTargetAction is the right place to do the targetDir snapshot.
+        -- It is incorrect to return anything here since the
+        -- dir which we just processed is not completed yet (as mentioned
+        -- above, we need to await the hp-specific packages to be built).
         GhcInstallCustom $ \bc distDir -> do
             void $ winGhcInstall winGhcTargetDir bc distDir
-            return ghcLocalDir
+            return Nothing
 
     osPackageTargetDir p = winHpPrefix </> packagePattern p
 

--- a/hptool/src/OS/Win.hs
+++ b/hptool/src/OS/Win.hs
@@ -52,7 +52,7 @@ winOsFromConfig BuildConfig{..} = os
 
     osPackageTargetDir p = winHpPrefix </> packagePattern p
 
-    -- The ghc-7.8.3 build for Windows does not have pre-built .dyn_hi files
+    -- The ghc builds for Windows do not have pre-built .dyn_hi files
     -- (Revisit this in future versions)
     osDoShared = False
 
@@ -86,7 +86,6 @@ winOsFromConfig BuildConfig{..} = os
     whenM mp m = mp >>= \p -> when p m
 
     osTargetAction = do
-        copyWinTargetExtras
         -- Now, targetDir is actually ready to snapshot (we skipped doing
         -- this in osGhcTargetInstall).
         void $ getDirectoryFiles "" [targetDir ++ "//*"]
@@ -123,12 +122,14 @@ winOsFromConfig BuildConfig{..} = os
 
     osProduct = winProductFile hpVersion bcArch
 
-    osRules _rel _bc = do
+    osRules _rel bc = do
         winRules
 
         osProduct %> \_ -> do
             need $ [dir ghcLocalDir, targetDir, vdir ghcVirtualTarget]
                    ++ winNeeds
+
+            copyWinTargetExtras bc
 
             -- Now, it is time to make sure there are no problems with the
             -- conf files copied to

--- a/hptool/src/OS/Win/WinNsis.hs
+++ b/hptool/src/OS/Win/WinNsis.hs
@@ -13,7 +13,7 @@ import Text.Hastache.Context (mkStrContext)
 import Config
 import OS.Win.WinPaths
 import OS.Win.WinUtils
-import Paths ( installerPartsDir, targetDir )
+import Paths ( installerPartsDir, phonyTargetDir )
 import Templates
 import Types
 import Utils
@@ -22,11 +22,11 @@ import Utils
 genNsisData :: Rules ()
 genNsisData = do
     nsisInstDat %> \dFile -> do
-        need [targetDir]
+        need [phonyTargetDir]
         dirs <- getDirsFiles filterEmptyDirs
         genData nsisInstDatTmpl dFile dirs
     nsisUninstDat %> \uFile -> do
-        need [targetDir]
+        need [phonyTargetDir]
         dirs <- getDirsFiles sortByDirRev
         genData nsisUninstDatTmpl uFile dirs
   where

--- a/hptool/src/OS/Win/WinPaths.hs
+++ b/hptool/src/OS/Win/WinPaths.hs
@@ -106,6 +106,12 @@ winExternalWinGhciDir = winExternalSrc </> "winghci"
 winWinGhciTargetDir :: FilePath
 winWinGhciTargetDir = winTargetDir </> "winghci"
 
+winExternalMSysDir :: BuildConfig -> FilePath
+winExternalMSysDir bc = winExternalSrc </> "msys" </> bcArch bc
+
+winMSysTargetDir :: FilePath
+winMSysTargetDir = winTargetDir </> "msys"
+
 -- | ghc.exe file, relative to the install
 winGhcExeBin :: FilePath
 winGhcExeBin = "bin" </> "ghc" <.> exe

--- a/hptool/src/OS/Win/WinRules.hs
+++ b/hptool/src/OS/Win/WinRules.hs
@@ -55,7 +55,7 @@ winGhcInstall destDir bc distDir = do
         winGlutIncSrcs
     needContents winGlutIncludeInstallDir
 
-    return destDir
+    return . Just $ destDir
 
 
 copyWinTargetExtras :: BuildConfig -> Action ()

--- a/hptool/src/OS/Win/WinRules.hs
+++ b/hptool/src/OS/Win/WinRules.hs
@@ -58,8 +58,8 @@ winGhcInstall destDir bc distDir = do
     return destDir
 
 
-copyWinTargetExtras :: Action ()
-copyWinTargetExtras = do
+copyWinTargetExtras :: BuildConfig -> Action ()
+copyWinTargetExtras bc = do
     -- copy icons
     let mkIconsDir = makeDirectory $ winTargetDir </> "icons"
     copyFilesAction mkIconsDir winExtrasSrc winTargetDir winIconsFiles
@@ -69,6 +69,9 @@ copyWinTargetExtras = do
 
     -- copy winghci pieces
     copyDirAction winExternalWinGhciDir winWinGhciTargetDir
+
+    -- copy msys(msys2) pieces
+    copyDirAction (winExternalMSysDir bc) winMSysTargetDir
 
 
 -- | These files are needed when building the installer

--- a/hptool/src/Paths.hs
+++ b/hptool/src/Paths.hs
@@ -18,7 +18,7 @@ module Paths
     , listBuild, listCore, listSource
     , hpCabalFile
 
-    , targetDir
+    , targetDir, phonyTargetDir
     , ghcVirtualTarget, hpVirtualTarget
 
     , installerPartsDir, extrasDir
@@ -110,6 +110,9 @@ hpCabalFile = buildRoot </> "haskell-platform.cabal"
 
 targetDir :: FilePath
 targetDir = buildRoot </> "target"
+
+phonyTargetDir :: FilePath
+phonyTargetDir = "PHONYtargetdir"
 
 ghcVirtualTarget :: String
 ghcVirtualTarget = "target-ghc"

--- a/hptool/src/Target.hs
+++ b/hptool/src/Target.hs
@@ -25,7 +25,7 @@ targetRules :: BuildConfig -> Rules ()
 targetRules bc = do
     buildRules
     installRules bc
-    targetDir ~> do
+    phonyTargetDir ~> do
         hpRel <- askHpRelease
         bc' <- askBuildConfig
         let OS{..} = osFromConfig bc'

--- a/hptool/src/Types.hs
+++ b/hptool/src/Types.hs
@@ -120,7 +120,7 @@ data BuildConfig = BuildConfig
 -- | A function that is used for the actions after untar-ing GHC.
 -- The build configuration and file path of the untar-ed directory is
 -- provided, and the file path of the installed directory is returned.
-type GhcInstallAction = BuildConfig -> FilePath -> Action FilePath
+type GhcInstallAction = BuildConfig -> FilePath -> Action (Maybe FilePath)
 
 -- | After untar-ing GHC, some platforms require configure-make, while
 -- other platforms need other custom steps.

--- a/windows-platform.sh
+++ b/windows-platform.sh
@@ -7,11 +7,12 @@ GHC_VERS=${tar_vers%%-*}
 
 # These may need to be edited to suit your specific environment
 # MSYS_BIN is needed on path for configure scripts;
-# HASK_BIN is needed on path for cabal.exe
+# HASK_BIN is needed on path for shake.exe, HsColour.exe (maybe cabal.exe)
 # NSIS_BIN is needed on path for makensisw.exe
 MSYS_BIN="/c/Program Files (x86)/MinGW/msys/1.0/bin"
-HASK_BIN="/c/Program Files (x86)/Haskell/bin"
+HASK_BIN="/c/Program Files/Haskell/bin:/c/Program Files/Haskell Platform/2014.2.0.0/lib/extralibs/bin"
 NSIS_BIN="/c/Program Files (x86)/NSIS"
+GHC_BINDIST=build/ghc-bindist/local
 
 HPTOOL=hptool/dist/build/hptool/hptool.exe
 
@@ -39,7 +40,6 @@ echo '***'
 (cd hptool; cabal build)
 
 CWD=`pwd`
-GHC_BINDIST=build/ghc-bindist/local
 MINGW=$GHC_BINDIST/mingw
 
 # A clean, well-lighted, cruft-free PATH

--- a/windows-platform.sh
+++ b/windows-platform.sh
@@ -92,6 +92,8 @@ if [ \! \(    -d winExternalSrc \
            -a -d winExternalSrc/doc/html \
            -a -d winExternalSrc/winghci \
            -a -e winExternalSrc/winghci/winghci.exe \
+           -a -d winExternalSrc/msys/i386/usr \
+           -a -d winExternalSrc/msys/x86_64/usr \
         \) ]
 then
     echo '***'
@@ -100,6 +102,7 @@ then
     echo '    * winghci (can copy from a previous HP release)'
     echo '    * GLUT library & DLL (e.g,. from freeglut-MinGW-2.8.1-1.mp.zip)'
     echo "    * GHC user's guide (matching the GHC in this HP)"
+    echo "    * MSys2 'usr' directory, as seen in git-for-windows(tm)"
     echo ''
     echo 'Please create a subdirectory in this directory (where this script'
     echo 'is), with the following contents and structure:'
@@ -124,7 +127,11 @@ then
             winghci/
                 winghci.exe
                 <and any other DLL, etc. needed to run this particular winghci>
-
+            msys/
+                i386/
+                        usr/{bin,lib,libexec,share,ssl}
+                x86_64/
+                        usr/{bin,lib,libexec,share,ssl}
 EOF
 
     exit 1


### PR DESCRIPTION
Github has lumped these all together, but the earlier 4 affect Windows HP only; the one about osGhcTargetInstall affects other platforms only with a type signature change; and the more recent, about un-overloading the targetDir target, affects all platforms in a hopefully benign, but possibly even beneficial, way (I am unable to easily test any of the linux-based builds).