### PR TITLE
symlink system installed bits into /usr/local/bin and /usr/local/share

### DIFF
--- a/hptool/os-extras/osx/bin/activate-hs
+++ b/hptool/os-extras/osx/bin/activate-hs
@@ -280,12 +280,12 @@ fi
 ### Set up /usr
 ###
 
-symLinkInto $ghcRoot/usr/bin/* /usr/bin
-symLinkInto $ghcRoot/usr/share/man/man1/* /usr/share/man/man1
-symLinkInto $ghcRoot/usr/share/doc/ghc /usr/share/doc
+symLinkInto $ghcRoot/usr/bin/* /usr/local/bin
+symLinkInto $ghcRoot/usr/share/man/man1/* /usr/local/share/man/man1
+symLinkInto $ghcRoot/usr/share/doc/ghc /usr/local/share/doc
 
 if [ -d "$hpRoot" ] ; then
-    symLinkInto $hpRoot/bin/* /usr/bin
+    symLinkInto $hpRoot/bin/* /usr/local/bin
 fi
 
 
@@ -327,7 +327,7 @@ if [ -f "$settingsFile" ] ; then
     else
         cmd=$( extractSetting "C compiler command" )
         if [ "$( determineCompiler $cmd )" = "clang" ] ; then
-            wrapperCmd=/usr/bin/ghc-clang-wrapper
+            wrapperCmd=/usr/local/bin/ghc-clang-wrapper
             if [ -f "$wrapperCmd" -a -e "$wrapperCmd" ] ; then
                 updateSetting "C compiler command" "$wrapperCmd"
             else
@@ -353,7 +353,7 @@ fi
 if [ -d "$hpRoot" ] ; then
     for conf in $hpRoot/lib/registrations/*
     do
-        run /usr/bin/ghc-pkg register --verbose=0 --force $conf 2>/dev/null
+        run /usr/local/bin/ghc-pkg register --verbose=0 --force $conf 2>/dev/null
     done
 fi
 

--- a/hptool/os-extras/osx/bin/uninstall-hs.hs
+++ b/hptool/os-extras/osx/bin/uninstall-hs.hs
@@ -1,4 +1,4 @@
-#!/usr/bin/env runghc
+#!/usr/local/bin/env runghc
 
 module Main where
 

--- a/hptool/os-extras/osx/doc/start.html.mu
+++ b/hptool/os-extras/osx/doc/start.html.mu
@@ -119,7 +119,7 @@ p {
       <p>On Mac OS X, the Haskell Platform is installed in two major pieces: GHC and Haskell Platform. They are installed respectively in:</p>
       <p class="paths">/Library/Frameworks/GHC.framework
       <br/>/Library/Haskell</p>
-      <p>Executables are symlinked in <tt>/usr/bin</tt> and should be available in any shell.</p>
+      <p>Executables are symlinked in <tt>/usr/local/bin</tt> and should be available in any shell.</p>
 
       <h2>Versions &amp; Uninstallation</h2>
       <p>This and prior versions of GHC and Haskell Platform can be found and then easily removed with the uninstallation command line utility:</p>


### PR DESCRIPTION
This change supports OS X El Capitan release where you can't install in /usr/bin directly anymore.