### PR TITLE
Add html flag for haddock invocation

### DIFF
--- a/hptool/src/Target.hs
+++ b/hptool/src/Target.hs
@@ -103,6 +103,7 @@ buildAction buildDir hpRel bc = do
         cabal "haddock" $
             [ "--hyperlink-source"
             , "--hoogle"
+            , "--html"
             , "--with-haddock=" ++ haddockExe `relativeToDir` buildDir
             ]
             ++ map (\s -> "--haddock-option=" ++ s) (cReadArgs ++ pReadArgs)


### PR DESCRIPTION
Seems we are no longer getting the html docs built.  Maybe
something is different in either haddock, or cabal's
invocation of it, as it used to work with no flag (supposedly
it is the haddock default?) but now appears we need it.

* hptool/src/Target.hs
  * add "--html" to haddock invocation