### PR TITLE
Tweak to GhcInstallAction; distinguish a phonyTargetDir

### DIFF
--- a/hptool/src/GhcDist.hs
+++ b/hptool/src/GhcDist.hs
@@ -39,7 +39,7 @@ cppCommandFlags cpp = case cpp of
 
 
 ghcInstall :: GhcInstall ->
-              FilePath -> Maybe (BuildConfig -> FilePath) -> Action FilePath
+              FilePath -> Maybe (BuildConfig -> FilePath) -> Action (Maybe FilePath)
 ghcInstall postUntarAction base mfPrefix = do
     tarFile <- askGhcBinDistTarFile
     conf <- askBuildConfig
@@ -74,7 +74,7 @@ ghcInstallConfigure base mfPrefix conf distDir = do
     Just cppCommand <- getCppCommand settings settingsFile
     writeSettings settingsFile (updateCppFlags cppCommand settings)
 
-    return destDir
+    return . Just $ destDir
   where
     layout Nothing = (base, base)
     layout (Just p) = (p, base </+> p)
@@ -113,7 +113,7 @@ ghcDistRules = do
         ghcInstall postUntar ghcLocalDir Nothing >> return ()
     ghcVirtualTarget ~/> do
         postUntar <- osGhcTargetInstall . osFromConfig <$> askBuildConfig
-        ghcInstall postUntar targetDir (Just targetPrefix) >>= return . Just
+        ghcInstall postUntar targetDir (Just targetPrefix)
   where
     targetPrefix = osGhcPrefix . osFromConfig
 

--- a/hptool/src/Main.hs
+++ b/hptool/src/Main.hs
@@ -110,7 +110,7 @@ whatIsIncluded rel = ("-- Minimal Platform:":minimalIncludes) ++ ("-- Full Platf
 buildRules :: Release -> FilePath -> BuildConfig -> Rules()
 buildRules hpRelease srcTarFile bc = do
     "build-source" ~> need [srcTarFile]
-    "build-target" ~> need [targetDir]
+    "build-target" ~> need [phonyTargetDir]
     "build-product" ~> need [osProduct]
     "build-local" ~> need [dir ghcLocalDir]
     "build-website" ~> need [dir websiteDir]

--- a/hptool/src/OS/Internal.hs
+++ b/hptool/src/OS/Internal.hs
@@ -124,7 +124,7 @@ genericOS BuildConfig{..} = OS{..}
     osProduct = productDir </> "generic.tar.gz"
     osRules _hpRelease _bc =
         osProduct %> \out -> do
-            need [targetDir, vdir ghcVirtualTarget]
+            need [phonyTargetDir, vdir ghcVirtualTarget]
             command_ [Cwd buildRoot]
                 "tar" ["czf", out `relativeToDir` buildRoot, targetDir `relativeToDir` buildRoot]
 

--- a/hptool/src/OS/Mac.hs
+++ b/hptool/src/OS/Mac.hs
@@ -139,7 +139,7 @@ macOsFromConfig BuildConfig{..} = OS{..}
                 ]
 
         hpPkgFile %> \out -> do
-            need [targetDir, dir extrasDir]  -- FIXME(mzero): could be more specific
+            need [phonyTargetDir, dir extrasDir]  -- FIXME(mzero): could be more specific
             command_ []
                 "pkgbuild"
                 [ "--identifier", "org.haskell.HaskellPlatform.Libraries."

--- a/hptool/src/OS/Posix.hs
+++ b/hptool/src/OS/Posix.hs
@@ -97,7 +97,7 @@ posixOS BuildConfig{..} = OS{..}
                 ]
 
         usrLocalTar %> \out -> do
-            need [targetDir, vdir ghcVirtualTarget]
+            need [phonyTargetDir, vdir ghcVirtualTarget]
             command_ [Cwd targetDir]
                 "tar" ["czf", out `relativeToDir` targetDir, hpTargetDir `relativeToDir` targetDir]
 

--- a/hptool/src/OS/Win.hs
+++ b/hptool/src/OS/Win.hs
@@ -54,10 +54,12 @@ winOsFromConfig BuildConfig{..} = os
         -- dependencies on the contents of winGhcTargetDir won't account
         -- for the HP pieces.  Also, for Windows, the ghc-bindist/local and
         -- the GHC installed into the targetDir should be identical.
-        -- osTargetAction is the right place to do the targetDir snapshot.
+        -- It is incorrect to return anything here since the
+        -- dir which we just processed is not completed yet (as mentioned
+        -- above, we need to await the hp-specific packages to be built).
         GhcInstallCustom $ \bc distDir -> do
             void $ winGhcInstall winGhcTargetDir bc distDir
-            return ghcLocalDir
+            return Nothing
 
     osPackageTargetDir p = winHpPrefix </> packagePattern p
 

--- a/hptool/src/OS/Win.hs
+++ b/hptool/src/OS/Win.hs
@@ -137,7 +137,7 @@ winOsFromConfig BuildConfig{..} = os
         winRules
 
         osProduct %> \_ -> do
-            need $ [dir ghcLocalDir, targetDir, vdir ghcVirtualTarget]
+            need $ [dir ghcLocalDir, phonyTargetDir, vdir ghcVirtualTarget]
                    ++ winNeeds
 
             copyWinTargetExtras bc

--- a/hptool/src/OS/Win/WinNsis.hs
+++ b/hptool/src/OS/Win/WinNsis.hs
@@ -13,7 +13,7 @@ import Text.Hastache.Context (mkStrContext)
 import Config
 import OS.Win.WinPaths
 import OS.Win.WinUtils
-import Paths ( installerPartsDir, targetDir )
+import Paths ( installerPartsDir, phonyTargetDir )
 import Templates
 import Types
 import Utils
@@ -22,11 +22,11 @@ import Utils
 genNsisData :: Rules ()
 genNsisData = do
     nsisInstDat %> \dFile -> do
-        need [targetDir]
+        need [phonyTargetDir]
         dirs <- getDirsFiles filterEmptyDirs
         genData nsisInstDatTmpl dFile dirs
     nsisUninstDat %> \uFile -> do
-        need [targetDir]
+        need [phonyTargetDir]
         dirs <- getDirsFiles sortByDirRev
         genData nsisUninstDatTmpl uFile dirs
   where

--- a/hptool/src/OS/Win/WinRules.hs
+++ b/hptool/src/OS/Win/WinRules.hs
@@ -56,7 +56,7 @@ winGhcInstall destDir bc distDir = do
         winGlutIncSrcs
     needContents winGlutIncludeInstallDir
 
-    return destDir
+    return . Just $ destDir
 
 
 copyWinTargetExtras :: BuildConfig -> Action ()

--- a/hptool/src/Paths.hs
+++ b/hptool/src/Paths.hs
@@ -18,7 +18,7 @@ module Paths
     , listBuild, listCore, listSource
     , hpCabalFile
 
-    , targetDir
+    , targetDir, phonyTargetDir
     , ghcVirtualTarget, hpVirtualTarget
 
     , installerPartsDir, extrasDir
@@ -110,6 +110,9 @@ hpCabalFile = buildRoot </> "haskell-platform.cabal"
 
 targetDir :: FilePath
 targetDir = buildRoot </> "target"
+
+phonyTargetDir :: FilePath
+phonyTargetDir = "PHONYtargetdir"
 
 ghcVirtualTarget :: String
 ghcVirtualTarget = "target-ghc"

--- a/hptool/src/Target.hs
+++ b/hptool/src/Target.hs
@@ -25,7 +25,7 @@ targetRules :: BuildConfig -> Rules ()
 targetRules bc = do
     buildRules
     installRules bc
-    targetDir ~> do
+    phonyTargetDir ~> do
         hpRel <- askHpRelease
         bc' <- askBuildConfig
         let OS{..} = osFromConfig bc'

--- a/hptool/src/Types.hs
+++ b/hptool/src/Types.hs
@@ -116,7 +116,7 @@ data BuildConfig = BuildConfig
 -- | A function that is used for the actions after untar-ing GHC.
 -- The build configuration and file path of the untar-ed directory is
 -- provided, and the file path of the installed directory is returned.
-type GhcInstallAction = BuildConfig -> FilePath -> Action FilePath
+type GhcInstallAction = BuildConfig -> FilePath -> Action (Maybe FilePath)
 
 -- | After untar-ing GHC, some platforms require configure-make, while
 -- other platforms need other custom steps.


### PR DESCRIPTION
These are two commits that have been needed for the Windows installer builds.  For the Windows HP build, the installation looks different on the user's machine from the other HP build environments. Due to this, these changes are specific to the Windows HP but are in code common to all environments.  I am unable to test these changes on those other build environments, so these changes should be applied with that caveat.  I have tried to make these edits innocuous to the other environments, but from HP build/installation problems in the past, I observe that those other environments have their own delicateness that might be affected.  The one involving GhcInstallAction is very unlikely to have any imact, but I am more concerned with the phonyTargetDir change's effects.
