### PR TITLE
Add GA tracking for flavors; more build tooling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ packages/
 src/generic/Build
 src/generic/haskell-platform-*
 src/macos/dist*
+.shake/
+config.platform
+ghc-*.tar.xz

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,38 @@
+
+Synopsis of build instructions:
+
+1. Use `find-bindist` to download a GHC bindist:
+
+        $ ./find-bindist apple
+        ... url displayed ...
+        $ wget ...url...
+
+2. If necessary, build `cabal` version >= 1.24:
+
+        $ cabal get cabal-install-1.24.0.0
+        $ cd cabal-install-1.24.0.0
+        $ cabal sandbox init
+        $ cabal install --only-dependencies
+        $ cabal install
+        $ cp ./dist/dist-sandbox-.../build/cabal/cabal /usr/local/bin/cabal
+
+3. Use `platform-init` to initialize the `config.platform` file:
+
+        $ ./platform-init
+
+    Make sure the version of cabal is >= 1.24. Edit entries as needed.
+
+4. Run `./new-platform.sh`
+
+        $ ./new-platform.sh build-all
+        $ ./new-platform.sh build-website
+
+    The website files reside in `build/product/website`.
+
+5. In a new terminal, start up the python server:
+
+        $ ./server ./build/product/website 12345
+
+    You can leave this running - it will track changes as you re-build
+    the website.
+

--- a/find-bindist
+++ b/find-bindist
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+#
+# Return the url for a GHC bindist.
+#
+# Examples:
+#   find-bindist apple
+#   find-bindist deb8 64
+#   find-bindist i3 ming
+#   find-bindist apple 7.10.2
+#   find-bindist               -- shows all bin dists
+
+import requests
+import re
+import os
+import sys
+
+BASE_URL = "http://downloads.haskell.org/~ghc"
+DEFAULT_GHC_VERSION = "8.0.1"
+
+def list_bin_dists(url):
+  r = requests.get(url)
+  contents = r.text
+  return re.findall('a href="(ghc-.*?.tar.xz)"', contents)
+
+def has_words(words, m):
+  for w in words:
+    if not (w in m):
+      return False
+  return True
+
+def is_ghc_vers(arg):
+  return re.match("(\d+)\.(\d+)\.(\d+)\Z", arg)
+
+def process_args(args):
+  versions = []
+  others = []
+  for arg in args:
+    if is_ghc_vers(arg):
+      versions.append(arg)
+    else:
+      others.append(arg)
+  return versions, others
+
+def main():
+  args = sys.argv[1:]
+
+  versions, words = process_args(sys.argv[1:])
+  if not versions:
+    versions.append(DEFAULT_GHC_VERSION)
+
+  ghc_vers = versions[0]
+
+  url = BASE_URL + "/" + ghc_vers + "/"
+  matches = [ m for m in list_bin_dists(url) if has_words(words, m) ]
+  if not matches:
+    if words:
+      msg = " contain the words: " + ", ".join(words)
+    else:
+      msg = ""
+    print "no bindists for version " + ghc_vers + msg
+  elif len(matches) == 1:
+    print url + matches[0]
+  else:
+    print "Multiple matching bindists:"
+    for m in matches:
+      print "  ", url + m
+
+main()
+ 

--- a/platform-init
+++ b/platform-init
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+#
+# Generate the config.platform file
+
+import glob
+import re
+import sys
+import os
+import subprocess
+
+def kvpair(k,v):
+  return k + '="{}"'.format(v)
+
+def which(file):
+    for path in os.environ["PATH"].split(os.pathsep):
+        if os.path.exists(os.path.join(path, file)):
+                return os.path.join(path, file)
+
+    return None
+
+def cabal_version(cabal):
+  output = subprocess.Popen([cabal, "--version"], stdout=subprocess.PIPE).communicate()[0]
+  # cabal-install version 1.22.6.0  
+  m = re.match("cabal-install version (\d[.\d]*)", output)
+  if m:
+    return m.groups(1)[0]
+  else:
+    return None
+
+def parse_version(s):
+  # s must be a string of digits and '.'
+  return [ int(x) for x in s.split('.') ]
+
+def compare_versions(a,b):
+  # print "compare_versions:, a:", a, "b:", b
+  if (not a) and (not b):
+    return 0
+  if not a:
+    if not b: return 0
+    return compare_versions( [0], b)
+  if not b:
+    return compare_versions( a, [0])
+  if int(a[0]) == int(b[0]):
+    return compare_versions(a[1:], b[1:])
+  return cmp(a[0], b[0])
+
+def main():
+  bindists = glob.glob("ghc-*.tar.xz")
+  if not bindists:
+    print "No GHC bindists found in the current working directory"
+    sys.exit(1)
+  elif len(bindists) > 1:
+    print "Multiple bindists found:"
+    for m in bindists:
+      print "  ", m
+    sys.exit(1)
+
+  stack = which("stack")
+  if not stack:
+    print "unable to find stack in PATH"
+    sys.exit(1)
+  print "found stack at", stack
+
+  cabal = which("cabal")
+  if not cabal:
+    print "unable to find cabal in PATH"
+    sys.exit(1)
+  print "found cabal at", stack
+
+  # Check the cabal version
+  cversion = cabal_version(cabal)
+  if not cversion:
+    print "unable to parse cabal version for", cabal
+    sys.exit(1)
+
+  bad_cabal = compare_versions([1,24], parse_version(cversion)) > 0
+  if bad_cabal:
+    cok = "NOT OK"
+  else:
+    cok = "OK"
+  print "cabal version is", cversion, "-", cok
+
+  if bad_cabal:
+    print "\n*** WARNING - cabal >= 1.24 required"
+
+  contents = "\n".join([ kvpair("GHC_BINDIST", bindists[0]), kvpair("STACK", stack), kvpair("CABAL", cabal) ]) + "\n"
+  with open("config.platform", "w") as f:
+    f.write(contents)
+  print "\nCreated the file config.platform with the contents:\n"
+  print contents
+
+main()

--- a/server
+++ b/server
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+import SocketServer
+import SimpleHTTPServer
+import urllib
+import posixpath
+import os
+import sys
+
+PORT = 1235
+BASE_DIR="/home/erantapaa/build-hp/haskell-platform/build/product/website"
+
+class Proxy(SimpleHTTPServer.SimpleHTTPRequestHandler):
+   def translate_path(self, path):
+        """Translate a /-separated PATH to the local filename syntax.
+        Components that mean special things to the local file system
+        (e.g. drive or directory names) are ignored.  (XXX They should
+        probably be diagnosed.)
+        """
+        # abandon query parameters
+        path = path.split('?',1)[0]
+        path = path.split('#',1)[0]
+        path = posixpath.normpath(urllib.unquote(path))
+        words = path.split('/')
+        words = filter(None, words)
+        path = BASE_DIR # os.getcwd()
+        for word in words:
+            drive, word = os.path.splitdrive(word)
+            head, word = os.path.split(word)
+            if word in (os.curdir, os.pardir): continue
+            path = os.path.join(path, word)
+        return path
+
+def main():
+  args = sys.argv[1:]
+  if len(args) < 2:
+    print "Usage: server directory port"
+    sys.exit(1)
+  BASE_DIR = args[0]
+  PORT = int(args[1])
+  httpd = SocketServer.ForkingTCPServer(('', PORT), Proxy)
+  print "serving at port", PORT
+  httpd.serve_forever()
+
+main()
+
+

--- a/website/plan-a/js/download.js
+++ b/website/plan-a/js/download.js
@@ -4,22 +4,6 @@ $(document).ready(function() {
     $('body').addClass('js');
 });
 
-$(document).ready(function() {
-    $('.expandable').each(function() {
-        var $this = $(this);
-        $this.children().wrapAll('<div class="contents"></div>')
-        var $contents = $this.children();
-        $contents.hide();
-
-        var $link = $('<a href="#">Click to expand</a>');
-        $this.prepend($link);
-
-        $link.click(function() {
-            $contents.slideToggle();
-        });
-    });
-});
-
 function identifyPlatform() {
     var ua = navigator.userAgent;
     var userAgents = {
@@ -105,3 +89,18 @@ $(document).ready(function() {
         window.history.replaceState({}, '', distro);
     });
 });
+
+// add GA events
+$(document).ready(function() {
+  // $('.platform-name').click(function(e) {
+  //   console.log("--- platform-name clicked")
+  //   return true
+  // });
+  $('.flavors ul li a').click(function(e) {
+    var which = this.getAttribute("href")
+    // console.log("--- flavor anchor clicked", which)
+    ga("send", "event", { eventCategory:"Download", eventAction:"flavor", eventLabel: which })
+    return true
+  });
+});
+

--- a/website/templates/plan-a/footer.mu
+++ b/website/templates/plan-a/footer.mu
@@ -19,7 +19,8 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-  go('create', 'UA-832905133-1', 'auto');
+  ga('create', 'UA-83290513-1', 'auto');
+  // ga('create', 'UA-78576289-1', 'auto'); // testing account
   ga('send', 'pageview');
   function dl(me) {
     ga('send','event',{eventCategory:'Download', eventAction:'Download HP', eventLabel:me.href})


### PR DESCRIPTION
This PR adds GA tracking to OS "flavor" selection.

The tracking changes are confined to `download.js` and footer.mu. I added other scripts which help with the build process. 

The events show up as `flavor` event actions and the event label is the flavor selected.
