### PR TITLE
Windows-only: work around 2GB payload limit of NSIS; plus 2 other

### DIFF
--- a/hptool/hptool.cabal
+++ b/hptool/hptool.cabal
@@ -59,4 +59,9 @@ Executable hptool
     text,
     transformers
 
+  if os(windows)
+    build-depends:
+      filepath,
+      unix-compat
+
   ghc-options: -Wall -fwarn-tabs

--- a/hptool/os-extras/win/templates/Extralibs.nsi.mu
+++ b/hptool/os-extras/win/templates/Extralibs.nsi.mu
@@ -1,0 +1,192 @@
+;; WARNING: Extralibs.nsi is automatically generated from Extralibs.nsi.mu by
+;; the hptool.  Make sure you are editing the template not the generated file.
+
+
+; Extralibs Installer
+
+;--------------------------------
+;Includes
+
+  !Include "FileFunc.nsh"
+  !Include "StrFunc.nsh"
+  !Include "LogicLib.nsh"
+  !Include "MUI2.nsh"
+  !Include "WordFunc.nsh"
+  !Include "x64.nsh"
+
+;--------------------------------
+;Defines
+
+  !Define GHC_VERSION "{{ghcVersion}}"
+  !Define PLATFORM_VERSION "{{hpVersion}}"
+  !Define PRODUCT_DIR_REG_KEY "Software\Haskell\Haskell Platform\${PLATFORM_VERSION}"
+  !Define HACKAGE_SHORTCUT_TEXT "HackageDB - Haskell Software Repository"
+  !Define FILES_SOURCE_PATH "{{targetFiles}}"
+  !Define INST_DAT "Extralibs_inst.dat"
+  !Define UNINST_DAT "Extralibs_uninst.dat"
+
+;--------------------------------
+;Variables
+
+  Var PROGRAM_FILES
+
+;--------------------------------
+;General settings
+
+  ;Name and file
+  Name "Haskell Platform ${PLATFORM_VERSION} {{is32or64}}-bit"
+  OutFile "{{productFile}}"
+
+  ;Default install dir
+  InstallDir "$PROGRAMFILES\Haskell Platform\${PLATFORM_VERSION}"
+  InstallDirRegKey HKLM "${PRODUCT_DIR_REG_KEY}" ""
+
+  ;Icon
+  !Define MUI_ICON "icons/installer.ico"
+  !Define MUI_UNICON "icons/installer.ico"
+
+  ;Request application privileges for Windows Vista
+  RequestExecutionLevel highest
+
+  ;Best available compression
+  SetCompressor /SOLID lzma
+
+  ;Install types
+  InstType "Standard"
+  InstType "Portable (just unpack the files)"
+
+;--------------------------------
+;Macros
+
+!macro CheckAdmin thing
+UserInfo::GetAccountType
+pop $0
+${If} $0 != "admin" ;Require admin rights on NT4+
+    MessageBox MB_YESNO "It is recommended to run this ${thing} as administrator. Do you want to quit and restart the ${thing} manually with elevated privileges?" IDNO CheckAdminDone
+    SetErrorLevel 740 ;ERROR_ELEVATION_REQUIRED
+    Quit
+${EndIf}
+CheckAdminDone:
+!macroend
+
+  ;--------------------------------
+  ;Win 64-bit support
+
+!macro do64Stuff isInstall
+  ; The NSIS installer is a 32-bit executable, but it can do a 64-bit install.
+  ; Default to 32-bit, change if installing 64-bit on 64-bit.
+  ;
+  ; The 'isInstall' argument is 1 for the install part of the script (from
+  ; .onInit function) and 0 if for the uninstall part (via un.onInit).  The
+  ; $INSTDIR must be changed for the installation step to account for the case
+  ; of installing the 32-bit installer onto 64-bit Windows; and and it must
+  ; happen before the user gets to the dialog to change installation location.
+  ; On the other hand, $INSTDIR must *not* be changed for the uninstall step
+  ; because doing so over-rides what the user did during the install step.
+  ;
+  ; Also, do not force $INSTDIR to change if this is a silent install.
+SetRegView 32
+StrCpy $PROGRAM_FILES "$PROGRAMFILES"
+${IfNot} ${Silent}
+  ${If} ${isInstall} = 1
+    StrCpy $INSTDIR "$PROGRAM_FILES\Haskell Platform\${PLATFORM_VERSION}"
+  ${EndIf}
+${EndIf}
+{{#build64bit}}
+${If} ${RunningX64}
+  ; If this is installing the 64-bit HP on 64-bit Windows, enable FSRedirection.
+  ${EnableX64FSRedirection}
+  ; enable access to 64-bit portion of registry
+  SetRegView 64
+  StrCpy $PROGRAM_FILES "$PROGRAMFILES64"
+  ${IfNot} ${Silent}
+    ${If} ${isInstall} = 1
+      StrCpy $INSTDIR "$PROGRAM_FILES\Haskell Platform\${PLATFORM_VERSION}"
+    ${EndIf}
+  ${EndIf}
+${Else}
+;     pop up an error message: Cannot install 64-bit HP on 32-bit Windows
+    MessageBox MB_OK "You are trying to install the 64-bit version of the Haskell Platform onto a 32-bit version of Windows.  Please use the 32-bit version of the Haskell Platform."
+    SetErrorLevel 0x800401FAL ; CO_E_WRONGOSFORAPP
+    Quit
+${EndIf}
+{{/build64bit}}
+!macroend
+
+;--------------------------------
+;Callbacks
+
+Function .onInit
+  !insertmacro do64Stuff 1
+  !insertmacro CheckAdmin "installer"
+  SetShellVarContext all
+FunctionEnd
+
+Function un.onInit
+  !insertmacro do64Stuff 0
+  !insertmacro CheckAdmin "uninstaller"
+  SetShellVarContext all
+FunctionEnd
+
+;--------------------------------
+;Interface Settings
+
+  !define MUI_ABORTWARNING
+
+;--------------------------------
+;Pages
+
+  !Define MUI_WELCOMEFINISHPAGE_BITMAP "welcome.bmp"
+  !insertmacro MUI_PAGE_WELCOME
+  !insertmacro MUI_PAGE_LICENSE "LICENSE"
+  !insertmacro MUI_PAGE_DIRECTORY
+
+  !Define MUI_COMPONENTSPAGE_NODESC
+  !insertmacro MUI_PAGE_COMPONENTS
+
+  !insertmacro MUI_PAGE_INSTFILES
+  !insertmacro MUI_PAGE_FINISH
+
+  !insertmacro MUI_UNPAGE_WELCOME
+  !insertmacro MUI_UNPAGE_CONFIRM
+  !insertmacro MUI_UNPAGE_INSTFILES
+  !insertmacro MUI_UNPAGE_FINISH
+
+;--------------------------------
+;Languages
+
+  !insertmacro MUI_LANGUAGE "English"
+
+;--------------------------------
+;Installer Sections
+
+Section "Base components" SecMain
+
+  SectionIn 1 2
+  ; Make this section mandatory
+  SectionIn RO
+
+  !Include ${INST_DAT}
+
+SectionEnd
+
+Section "Create uninstaller" SecAddRem
+
+  SectionIn 1
+  SectionIn RO
+
+  ;Create uninstaller
+  WriteUninstaller "$INSTDIR\Extralibs_Uninstall.exe"
+
+SectionEnd
+
+;--------------------------------
+;Uninstaller Section
+
+Section "Uninstall"
+
+  !Include ${UNINST_DAT}
+
+  Delete "$INSTDIR\Extralibs_Uninstall.exe"
+
+SectionEnd

--- a/hptool/os-extras/win/templates/GHC.nsi.mu
+++ b/hptool/os-extras/win/templates/GHC.nsi.mu
@@ -1,0 +1,192 @@
+;; WARNING: GHC.nsi is automatically generated from GHC.nsi.mu by
+;; the hptool.  Make sure you are editing the template not the generated file.
+
+
+; GHC Installer
+
+;--------------------------------
+;Includes
+
+  !Include "FileFunc.nsh"
+  !Include "StrFunc.nsh"
+  !Include "LogicLib.nsh"
+  !Include "MUI2.nsh"
+  !Include "WordFunc.nsh"
+  !Include "x64.nsh"
+
+;--------------------------------
+;Defines
+
+  !Define GHC_VERSION "{{ghcVersion}}"
+  !Define PLATFORM_VERSION "{{hpVersion}}"
+  !Define PRODUCT_DIR_REG_KEY "Software\Haskell\Haskell Platform\${PLATFORM_VERSION}"
+  !Define HACKAGE_SHORTCUT_TEXT "HackageDB - Haskell Software Repository"
+  !Define FILES_SOURCE_PATH "{{targetFiles}}"
+  !Define INST_DAT "GHC_inst.dat"
+  !Define UNINST_DAT "GHC_uninst.dat"
+
+;--------------------------------
+;Variables
+
+  Var PROGRAM_FILES
+
+;--------------------------------
+;General settings
+
+  ;Name and file
+  Name "Haskell Platform ${PLATFORM_VERSION} {{is32or64}}-bit"
+  OutFile "{{productFile}}"
+
+  ;Default install dir
+  InstallDir "$PROGRAMFILES\Haskell Platform\${PLATFORM_VERSION}"
+  InstallDirRegKey HKLM "${PRODUCT_DIR_REG_KEY}" ""
+
+  ;Icon
+  !Define MUI_ICON "icons/installer.ico"
+  !Define MUI_UNICON "icons/installer.ico"
+
+  ;Request application privileges for Windows Vista
+  RequestExecutionLevel highest
+
+  ;Best available compression
+  SetCompressor /SOLID lzma
+
+  ;Install types
+  InstType "Standard"
+  InstType "Portable (just unpack the files)"
+
+;--------------------------------
+;Macros
+
+!macro CheckAdmin thing
+UserInfo::GetAccountType
+pop $0
+${If} $0 != "admin" ;Require admin rights on NT4+
+    MessageBox MB_YESNO "It is recommended to run this ${thing} as administrator. Do you want to quit and restart the ${thing} manually with elevated privileges?" IDNO CheckAdminDone
+    SetErrorLevel 740 ;ERROR_ELEVATION_REQUIRED
+    Quit
+${EndIf}
+CheckAdminDone:
+!macroend
+
+  ;--------------------------------
+  ;Win 64-bit support
+
+!macro do64Stuff isInstall
+  ; The NSIS installer is a 32-bit executable, but it can do a 64-bit install.
+  ; Default to 32-bit, change if installing 64-bit on 64-bit.
+  ;
+  ; The 'isInstall' argument is 1 for the install part of the script (from
+  ; .onInit function) and 0 if for the uninstall part (via un.onInit).  The
+  ; $INSTDIR must be changed for the installation step to account for the case
+  ; of installing the 32-bit installer onto 64-bit Windows; and and it must
+  ; happen before the user gets to the dialog to change installation location.
+  ; On the other hand, $INSTDIR must *not* be changed for the uninstall step
+  ; because doing so over-rides what the user did during the install step.
+  ;
+  ; Also, do not force $INSTDIR to change if this is a silent install.
+SetRegView 32
+StrCpy $PROGRAM_FILES "$PROGRAMFILES"
+${IfNot} ${Silent}
+  ${If} ${isInstall} = 1
+    StrCpy $INSTDIR "$PROGRAM_FILES\Haskell Platform\${PLATFORM_VERSION}"
+  ${EndIf}
+${EndIf}
+{{#build64bit}}
+${If} ${RunningX64}
+  ; If this is installing the 64-bit HP on 64-bit Windows, enable FSRedirection.
+  ${EnableX64FSRedirection}
+  ; enable access to 64-bit portion of registry
+  SetRegView 64
+  StrCpy $PROGRAM_FILES "$PROGRAMFILES64"
+  ${IfNot} ${Silent}
+    ${If} ${isInstall} = 1
+      StrCpy $INSTDIR "$PROGRAM_FILES\Haskell Platform\${PLATFORM_VERSION}"
+    ${EndIf}
+  ${EndIf}
+${Else}
+;     pop up an error message: Cannot install 64-bit HP on 32-bit Windows
+    MessageBox MB_OK "You are trying to install the 64-bit version of the Haskell Platform onto a 32-bit version of Windows.  Please use the 32-bit version of the Haskell Platform."
+    SetErrorLevel 0x800401FAL ; CO_E_WRONGOSFORAPP
+    Quit
+${EndIf}
+{{/build64bit}}
+!macroend
+
+;--------------------------------
+;Callbacks
+
+Function .onInit
+  !insertmacro do64Stuff 1
+  !insertmacro CheckAdmin "installer"
+  SetShellVarContext all
+FunctionEnd
+
+Function un.onInit
+  !insertmacro do64Stuff 0
+  !insertmacro CheckAdmin "uninstaller"
+  SetShellVarContext all
+FunctionEnd
+
+;--------------------------------
+;Interface Settings
+
+  !define MUI_ABORTWARNING
+
+;--------------------------------
+;Pages
+
+  !Define MUI_WELCOMEFINISHPAGE_BITMAP "welcome.bmp"
+  !insertmacro MUI_PAGE_WELCOME
+  !insertmacro MUI_PAGE_LICENSE "LICENSE"
+  !insertmacro MUI_PAGE_DIRECTORY
+
+  !Define MUI_COMPONENTSPAGE_NODESC
+  !insertmacro MUI_PAGE_COMPONENTS
+
+  !insertmacro MUI_PAGE_INSTFILES
+  !insertmacro MUI_PAGE_FINISH
+
+  !insertmacro MUI_UNPAGE_WELCOME
+  !insertmacro MUI_UNPAGE_CONFIRM
+  !insertmacro MUI_UNPAGE_INSTFILES
+  !insertmacro MUI_UNPAGE_FINISH
+
+;--------------------------------
+;Languages
+
+  !insertmacro MUI_LANGUAGE "English"
+
+;--------------------------------
+;Installer Sections
+
+Section "Base components" SecMain
+
+  SectionIn 1 2
+  ; Make this section mandatory
+  SectionIn RO
+
+  !Include ${INST_DAT}
+
+SectionEnd
+
+Section "Create uninstaller" SecAddRem
+
+  SectionIn 1
+  SectionIn RO
+
+  ;Create uninstaller
+  WriteUninstaller "$INSTDIR\GHC_Uninstall.exe"
+
+SectionEnd
+
+;--------------------------------
+;Uninstaller Section
+
+Section "Uninstall"
+
+  !Include ${UNINST_DAT}
+
+  Delete "$INSTDIR\GHC_Uninstall.exe"
+
+SectionEnd

--- a/hptool/os-extras/win/templates/MSys.nsi.mu
+++ b/hptool/os-extras/win/templates/MSys.nsi.mu
@@ -1,0 +1,192 @@
+;; WARNING: MSys.nsi is automatically generated from MSys.nsi.mu by
+;; the hptool.  Make sure you are editing the template not the generated file.
+
+
+; MSys Installer
+
+;--------------------------------
+;Includes
+
+  !Include "FileFunc.nsh"
+  !Include "StrFunc.nsh"
+  !Include "LogicLib.nsh"
+  !Include "MUI2.nsh"
+  !Include "WordFunc.nsh"
+  !Include "x64.nsh"
+
+;--------------------------------
+;Defines
+
+  !Define GHC_VERSION "{{ghcVersion}}"
+  !Define PLATFORM_VERSION "{{hpVersion}}"
+  !Define PRODUCT_DIR_REG_KEY "Software\Haskell\Haskell Platform\${PLATFORM_VERSION}"
+  !Define HACKAGE_SHORTCUT_TEXT "HackageDB - Haskell Software Repository"
+  !Define FILES_SOURCE_PATH "{{targetFiles}}"
+  !Define INST_DAT "MSys_inst.dat"
+  !Define UNINST_DAT "MSys_uninst.dat"
+
+;--------------------------------
+;Variables
+
+  Var PROGRAM_FILES
+
+;--------------------------------
+;General settings
+
+  ;Name and file
+  Name "Haskell Platform ${PLATFORM_VERSION} {{is32or64}}-bit"
+  OutFile "{{productFile}}"
+
+  ;Default install dir
+  InstallDir "$PROGRAMFILES\Haskell Platform\${PLATFORM_VERSION}"
+  InstallDirRegKey HKLM "${PRODUCT_DIR_REG_KEY}" ""
+
+  ;Icon
+  !Define MUI_ICON "icons/installer.ico"
+  !Define MUI_UNICON "icons/installer.ico"
+
+  ;Request application privileges for Windows Vista
+  RequestExecutionLevel highest
+
+  ;Best available compression
+  SetCompressor /SOLID lzma
+
+  ;Install types
+  InstType "Standard"
+  InstType "Portable (just unpack the files)"
+
+;--------------------------------
+;Macros
+
+!macro CheckAdmin thing
+UserInfo::GetAccountType
+pop $0
+${If} $0 != "admin" ;Require admin rights on NT4+
+    MessageBox MB_YESNO "It is recommended to run this ${thing} as administrator. Do you want to quit and restart the ${thing} manually with elevated privileges?" IDNO CheckAdminDone
+    SetErrorLevel 740 ;ERROR_ELEVATION_REQUIRED
+    Quit
+${EndIf}
+CheckAdminDone:
+!macroend
+
+  ;--------------------------------
+  ;Win 64-bit support
+
+!macro do64Stuff isInstall
+  ; The NSIS installer is a 32-bit executable, but it can do a 64-bit install.
+  ; Default to 32-bit, change if installing 64-bit on 64-bit.
+  ;
+  ; The 'isInstall' argument is 1 for the install part of the script (from
+  ; .onInit function) and 0 if for the uninstall part (via un.onInit).  The
+  ; $INSTDIR must be changed for the installation step to account for the case
+  ; of installing the 32-bit installer onto 64-bit Windows; and and it must
+  ; happen before the user gets to the dialog to change installation location.
+  ; On the other hand, $INSTDIR must *not* be changed for the uninstall step
+  ; because doing so over-rides what the user did during the install step.
+  ;
+  ; Also, do not force $INSTDIR to change if this is a silent install.
+SetRegView 32
+StrCpy $PROGRAM_FILES "$PROGRAMFILES"
+${IfNot} ${Silent}
+  ${If} ${isInstall} = 1
+    StrCpy $INSTDIR "$PROGRAM_FILES\Haskell Platform\${PLATFORM_VERSION}"
+  ${EndIf}
+${EndIf}
+{{#build64bit}}
+${If} ${RunningX64}
+  ; If this is installing the 64-bit HP on 64-bit Windows, enable FSRedirection.
+  ${EnableX64FSRedirection}
+  ; enable access to 64-bit portion of registry
+  SetRegView 64
+  StrCpy $PROGRAM_FILES "$PROGRAMFILES64"
+  ${IfNot} ${Silent}
+    ${If} ${isInstall} = 1
+      StrCpy $INSTDIR "$PROGRAM_FILES\Haskell Platform\${PLATFORM_VERSION}"
+    ${EndIf}
+  ${EndIf}
+${Else}
+;     pop up an error message: Cannot install 64-bit HP on 32-bit Windows
+    MessageBox MB_OK "You are trying to install the 64-bit version of the Haskell Platform onto a 32-bit version of Windows.  Please use the 32-bit version of the Haskell Platform."
+    SetErrorLevel 0x800401FAL ; CO_E_WRONGOSFORAPP
+    Quit
+${EndIf}
+{{/build64bit}}
+!macroend
+
+;--------------------------------
+;Callbacks
+
+Function .onInit
+  !insertmacro do64Stuff 1
+  !insertmacro CheckAdmin "installer"
+  SetShellVarContext all
+FunctionEnd
+
+Function un.onInit
+  !insertmacro do64Stuff 0
+  !insertmacro CheckAdmin "uninstaller"
+  SetShellVarContext all
+FunctionEnd
+
+;--------------------------------
+;Interface Settings
+
+  !define MUI_ABORTWARNING
+
+;--------------------------------
+;Pages
+
+  !Define MUI_WELCOMEFINISHPAGE_BITMAP "welcome.bmp"
+  !insertmacro MUI_PAGE_WELCOME
+  !insertmacro MUI_PAGE_LICENSE "LICENSE"
+  !insertmacro MUI_PAGE_DIRECTORY
+
+  !Define MUI_COMPONENTSPAGE_NODESC
+  !insertmacro MUI_PAGE_COMPONENTS
+
+  !insertmacro MUI_PAGE_INSTFILES
+  !insertmacro MUI_PAGE_FINISH
+
+  !insertmacro MUI_UNPAGE_WELCOME
+  !insertmacro MUI_UNPAGE_CONFIRM
+  !insertmacro MUI_UNPAGE_INSTFILES
+  !insertmacro MUI_UNPAGE_FINISH
+
+;--------------------------------
+;Languages
+
+  !insertmacro MUI_LANGUAGE "English"
+
+;--------------------------------
+;Installer Sections
+
+Section "Base components" SecMain
+
+  SectionIn 1 2
+  ; Make this section mandatory
+  SectionIn RO
+
+  !Include ${INST_DAT}
+
+SectionEnd
+
+Section "Create uninstaller" SecAddRem
+
+  SectionIn 1
+  SectionIn RO
+
+  ;Create uninstaller
+  WriteUninstaller "$INSTDIR\MSys_Uninstall.exe"
+
+SectionEnd
+
+;--------------------------------
+;Uninstaller Section
+
+Section "Uninstall"
+
+  !Include ${UNINST_DAT}
+
+  Delete "$INSTDIR\MSys_Uninstall.exe"
+
+SectionEnd

--- a/hptool/src/OS/Win.hs
+++ b/hptool/src/OS/Win.hs
@@ -143,6 +143,7 @@ winOsFromConfig BuildConfig{..} = os
             void $ getDirectoryFiles "" [targetDir ++ "//*"]
 
             need winNeeds
+            need winExtraNeeds
 
             -- Now, it is time to make sure there are no problems with the
             -- conf files copied to
@@ -153,7 +154,10 @@ winOsFromConfig BuildConfig{..} = os
                 [ "check"
                 , "--package-db=" ++ winGhcTargetPackageDbDir ]
 
-          -- Build installer now; makensis must be run in installerPartsDir
+            -- Build installer now; makensis must be run in installerPartsDir
+            command_ [Cwd installerPartsDir] "makensis" [extralibsNsisFileName]
+            command_ [Cwd installerPartsDir] "makensis" [msysNsisFileName]
+            command_ [Cwd installerPartsDir] "makensis" [ghcNsisFileName]
             command_ [Cwd installerPartsDir] "makensis" [nsisFileName]
 
     osPackageConfigureExtraArgs _ =

--- a/hptool/src/OS/Win.hs
+++ b/hptool/src/OS/Win.hs
@@ -96,10 +96,7 @@ winOsFromConfig BuildConfig{..} = os
     whenM :: (Monad m) => m Bool -> m () -> m ()
     whenM mp m = mp >>= \p -> when p m
 
-    osTargetAction = do
-        -- Now, targetDir is actually ready to snapshot (we skipped doing
-        -- this in osGhcTargetInstall).
-        void $ getDirectoryFiles "" [targetDir ++ "//*"]
+    osTargetAction = return ()
 
     osGhcDbDir = winGhcPackageDbDir
 
@@ -138,9 +135,14 @@ winOsFromConfig BuildConfig{..} = os
 
         osProduct %> \_ -> do
             need $ [dir ghcLocalDir, phonyTargetDir, vdir ghcVirtualTarget]
-                   ++ winNeeds
 
             copyWinTargetExtras bc
+
+            -- Now, targetDir is actually ready to snapshot (we skipped doing
+            -- this in osGhcTargetInstall).
+            void $ getDirectoryFiles "" [targetDir ++ "//*"]
+
+            need winNeeds
 
             -- Now, it is time to make sure there are no problems with the
             -- conf files copied to

--- a/hptool/src/OS/Win/WinNsis.hs
+++ b/hptool/src/OS/Win/WinNsis.hs
@@ -1,51 +1,99 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module OS.Win.WinNsis ( genNsisData, genNsisFile ) where
+module OS.Win.WinNsis ( genNsisFiles ) where
 
-import Control.Applicative ( (<$>), (<*>), pure )
+import Control.Monad ( join )
 import Data.List ( sortBy )
 import Data.Ord ( comparing )
+import Data.Version ( Version )
 import Development.Shake
-import Development.Shake.FilePath ( toNative, takeDirectory )
+import Development.Shake.FilePath ( toNative, takeDirectory, takeFileName )
+import System.FilePath ( equalFilePath, splitDirectories )
+import System.Posix.Types ( FileOffset )
+import System.PosixCompat.Files ( fileSize, getFileStatus )
 import Text.Hastache ( MuType(..), MuContext )
 import Text.Hastache.Context (mkStrContext)
 
 import Config
 import OS.Win.WinPaths
 import OS.Win.WinUtils
-import Paths ( installerPartsDir, phonyTargetDir )
+import Paths ( phonyTargetDir )
 import Templates
 import Types
 import Utils
 
 
-genNsisData :: Rules ()
-genNsisData = do
-    nsisInstDat %> \dFile -> do
-        need [phonyTargetDir]
-        dirs <- getDirsFiles filterEmptyDirs
-        genData nsisInstDatTmpl dFile dirs
-    nsisUninstDat %> \uFile -> do
-        need [phonyTargetDir]
-        dirs <- getDirsFiles sortByDirRev
-        genData nsisUninstDatTmpl uFile dirs
+data InfoForTemplate = InfoForTemplate
+    { iftGetProdName :: (Bool -> Version -> String -> FilePath)
+    , iftNSISFile :: FilePath
+    , iftStackFile :: FilePath
+    , iftStackInstalledSize :: FileOffset
+    , iftMainInstalledSize :: FileOffset
+    }
+
+-- | Using a template, generate the NSIS files.  Note that this file will
+-- contain definitions of variables which are used by the inst.dat and
+-- uninst.dat files (which get included into the NSIS file during the build
+-- of the installer).  That is, there is a coupling between these files.
+genNsisFiles :: Rules ()
+genNsisFiles = do
+    ghcNsisInstDat %> makeInstDat ghcInstFilter winTargetDir
+    ghcNsisUninstDat %> makeUninstDat ghcUninstFilter winTargetDir
+
+    msysNsisInstDat %> makeInstDat filterEmptyDirs winMSysTargetDir
+    msysNsisUninstDat %> makeUninstDat sortByDirRev winMSysTargetDir
+
+    extralibsNsisInstDat %> makeInstDat filterEmptyDirs winHpTargetDir
+    extralibsNsisUninstDat %> makeUninstDat sortByDirRev winHpTargetDir
+
+    nsisFile %> expandAndCopy nsiTemplate winProductFile
+    ghcNsisFile %> expandAndCopy ghcNsiTemplate ghcProductFile
+    msysNsisFile %> expandAndCopy msysNsiTemplate msysProductFile
+    extralibsNsisFile %> expandAndCopy extralibsNsiTemplate extralibsProductFile
   where
+    makeInstDat instFilter targDir dFile = do
+        need [phonyTargetDir]
+        dirs <- getDirsFiles instFilter targDir
+        genData nsisInstDatTmpl dFile dirs
+    makeUninstDat uninstFilter targDir uFile = do
+        need [phonyTargetDir]
+        dirs <- getDirsFiles uninstFilter targDir
+        genData nsisUninstDatTmpl uFile dirs
+
+    -- ghc bucket covers all directories and files not in msys or extralibs
+    -- since targetDir contains the msys sub-dir as well as lib/extralibs,
+    -- we need to filter those paths out as they are covered by the
+    -- msys and extralibs .dat lists.  N.b.: Filtering by names could be
+    -- fragile in light of any directory, package, structuring changes.
+    -- Also note that even in for the "minimal" HP build, there are still
+    -- a few things in extralibs (specifically alex and happy, as well as
+    -- the cabal executable.)
+    ghcInstFilter = filterEmptyDirs . skipExtralibs . skipMSys
+    ghcUninstFilter =  sortByDirRev . skipExtralibs . skipMSys
+
     -- For install, sort doesn't matter when parent vs child dir is created;
     -- For uninstall, deeper directories must be removed before their parent
-    sortByDirRev = sortBy (flip (comparing fst)) -- 'flip' comparing --> 'reverse'
+    sortByDirRev = sortBy (flip (comparing fst))
+        -- 'flip' comparing --> 'reverse'
 
     -- Filter directories with no files (but other directories are ok) for
     -- install but leave them for uninstall.
     filterEmptyDirs = filter (\(_,fs) -> not $ null fs)
 
-    getDirsFiles f = liftIO $
-                     makeNativeRelPaths <$>
-                     f <$>
-                     getDirContentsR winTargetDir
+    skipExtralibs = filter (\(d, _) ->
+        not $ any (equalFilePath "extralibs") (splitDirectories d))
+
+    skipMSys = filter (\(d, _) ->
+        not $ any (equalFilePath "msys") (splitDirectories d))
+
+    getDirsFiles f dir = liftIO $
+        makeNativeRelPaths <$>
+        f <$>
+        getDirContentsR dir
       where
+        makeNativeRelPath = toNative . (`relativeToDir` winTargetDir)
         makeNativeRelPaths =
-            map (\(d,fs) -> ( toNative $ d `relativeToDir` winTargetDir
-                            , map (toNative . (`relativeToDir` winTargetDir)) fs))
+            map (\(d,fs) -> ( makeNativeRelPath d, map makeNativeRelPath fs ))
 
     genData tmpl file dirs = do
         ctx <- mu <$> pure tmpl <*> pure dirs
@@ -66,34 +114,53 @@ genNsisData = do
         exFile _ t = error $ "GenNsis.exFile: unexpected template tag " ++ t ++
                      " while processing '" ++ tmpl ++ "'"
 
--- | Using a template, generate the NSIS file.  Note that this file will
--- contain definitions of variables which are used by the inst.dat and
--- uninst.dat files (which get included into the NSIS file during the build
--- of the installer).  That is, there is a coupling between these files.
-genNsisFile :: Rules ()
-genNsisFile =
-    nsisFile %> \nFile -> do
+    getFileSize :: FilePath -> IO FileOffset
+    getFileSize f = fileSize <$> getFileStatus f
+    getDirContentSize f dir = liftIO $
+        (sum <$>) $
+        join $ (mapM (\(_,fs) -> sum <$> mapM getFileSize fs)) <$>
+        f <$>
+        getDirContentsR dir
+
+    expandAndCopy templ pFile nFile = do
+        stackFile <- askStackExe
         bc <- askBuildConfig
         rls <- askHpRelease
         pCtx <- platformContext
-        let nsisCtx = expandNsisInfo rls bc
+        mainSize <- getDirContentSize filterEmptyDirs winTargetDir
+        let nsisCtx = expandNsisInfo rls bc ift
             ctx = nsisCtx `ctxAppend` pCtx
-        copyExpandedFile ctx nsiTemplate nFile
+            stackSize = 37 * 1024 * 1024 -- not sure how to actually determine
+            ift = InfoForTemplate pFile nFile stackFile stackSize mainSize
+        copyExpandedFile ctx templ nFile
 
-expandNsisInfo :: (Monad m) => Release -> BuildConfig -> MuContext m
-expandNsisInfo rls BuildConfig{..} = mkStrContext ex
+expandNsisInfo :: (Monad m) => Release -> BuildConfig -> InfoForTemplate ->
+                  MuContext m
+expandNsisInfo rls BuildConfig{..} InfoForTemplate{..} = mkStrContext ex
   where
-    ex "productFile" = MuVariable . toNative $
-        winProductFile bcIncludeExtra hpver bcArch `relativeToDir` installerPartsDir
+    productFile = iftGetProdName bcIncludeExtra hpver bcArch
+        `relativeToDir` takeDirectory iftNSISFile
         -- NSIS tool needs to run from the installerPartsDir
+
+    ex "productFile" = MuVariable . toNative $ productFile
     ex "build64bit" = MuBool is64
     ex "is32or64" = MuVariable $ if is64 then "64" else "32"
     ex "programFiles64" = MuVariable $ if is64 then "64" else ""
     ex "targetFiles" = MuVariable . toNative $
-        winTargetDir `relativeToDir` takeDirectory nsisFile
-        -- NSIS is run from where nsisFile is, so make relative to that
-
+        winTargetDir `relativeToDir` takeDirectory iftNSISFile
+        -- NSIS is run from where the nsis is, so make relative to that
+    ex "includeExtras" = MuBool bcIncludeExtra
+    ex "mainInstalledSize" = MuVariable . show . inKB $ iftMainInstalledSize
+    ex "stackInstallerPath" = MuVariable . toNative $
+        iftStackFile `relativeToDir` takeDirectory iftNSISFile
+        -- NSIS is run from where the nsis is, so make relative to that
+    ex "stackInstallerFileName" = MuVariable . toNative $
+        takeFileName iftStackFile
+    ex "stackInstalledSize" = MuVariable . show . inKB $ iftStackInstalledSize
     ex _ = MuNothing
 
     is64 = bcArch == "x86_64"
     hpver = hpVersion . relVersion $ rls
+    -- NSIS wants this in "kilobytes"
+    inKB :: FileOffset -> Int
+    inKB b = truncate $ (fromIntegral b) / (1024::Double)

--- a/hptool/src/OS/Win/WinPaths.hs
+++ b/hptool/src/OS/Win/WinPaths.hs
@@ -18,7 +18,9 @@ winExtrasSrc = "hptool/os-extras/win"
 winTemplates :: FilePath
 winTemplates = winExtrasSrc </> "templates"
 
+
 -- | File name of the data file used by NSIS to create the installer exe
+-- (this is everything (including GHC) that is not MSys or extralibs)
 nsisFileName :: FilePath
 nsisFileName = "Nsisfile.nsi"
 
@@ -26,25 +28,98 @@ nsisFileName = "Nsisfile.nsi"
 nsisFile :: FilePath
 nsisFile = installerPartsDir </> nsisFileName
 
-nsisInstDat :: FilePath
-nsisInstDat = installerPartsDir </> "inst.dat"
 
-nsisUninstDat :: FilePath
-nsisUninstDat = installerPartsDir </> "uninst.dat"
+-- | MSys installation data files
+msysNsisFileName :: FilePath
+msysNsisFileName = "MSys.nsi"
+
+msysNsisFile :: FilePath
+msysNsisFile = installerPartsDir </> msysNsisFileName
+
+msysNsisInstDat :: FilePath
+msysNsisInstDat = installerPartsDir </> "MSys_inst.dat"
+
+msysNsisUninstDat :: FilePath
+msysNsisUninstDat = installerPartsDir </> "MSys_uninst.dat"
+
+-- | The msys sub-installer file name; it is internal only
+msysProductFileName :: FilePath
+msysProductFileName = "MSys-setup" <.> "exe"
+
+-- | Directory where the MSys sub-installer file is built.
+msysProductFile :: Bool -> Version -> String -> FilePath
+msysProductFile _isFull _hpv _arch = productDir </> msysProductFileName
+
+
+-- | Extralibs installation data files
+extralibsNsisFileName :: FilePath
+extralibsNsisFileName = "Extralibs.nsi"
+
+extralibsNsisFile :: FilePath
+extralibsNsisFile = installerPartsDir </> extralibsNsisFileName
+
+extralibsNsisInstDat :: FilePath
+extralibsNsisInstDat = installerPartsDir </> "Extralibs_inst.dat"
+
+extralibsNsisUninstDat :: FilePath
+extralibsNsisUninstDat = installerPartsDir </> "Extralibs_uninst.dat"
+
+-- | The extralibs sub-installer file name; it is internal only
+extralibsProductFileName :: FilePath
+extralibsProductFileName = "Extralibs-setup" <.> "exe"
+
+-- | Directory where the extralibs sub-installer file is built.
+extralibsProductFile :: Bool -> Version -> String -> FilePath
+extralibsProductFile _ _ _ = productDir </> extralibsProductFileName
+
+
+-- | GHC installation data files
+ghcNsisFileName :: FilePath
+ghcNsisFileName = "GHC.nsi"
+
+ghcNsisFile :: FilePath
+ghcNsisFile = installerPartsDir </> ghcNsisFileName
+
+ghcNsisInstDat :: FilePath
+ghcNsisInstDat = installerPartsDir </> "GHC_inst.dat"
+
+ghcNsisUninstDat :: FilePath
+ghcNsisUninstDat = installerPartsDir </> "GHC_uninst.dat"
+
+-- | The GHC sub-installer file name; it is internal only
+ghcProductFileName :: FilePath
+ghcProductFileName = "GHC-setup" <.> "exe"
+
+-- | Directory where the GHC sub-installer file is built.
+ghcProductFile :: Bool -> Version -> String -> FilePath
+ghcProductFile _ _ _ = productDir </> ghcProductFileName
+
 
 -- | Pre-built or unchanging files that need to be included in the installer
 winInstExtras :: [FilePath]
 winInstExtras = map (installerPartsDir </>) winInstExtrasFiles
 
+
 -- | Templates to generate some of the installer data files
 nsiTemplate :: FilePath
 nsiTemplate = winTemplates </> "Nsisfile.nsi.mu"
+
+msysNsiTemplate :: FilePath
+msysNsiTemplate = winTemplates </> "MSys.nsi.mu"
+
+extralibsNsiTemplate :: FilePath
+extralibsNsiTemplate = winTemplates </> "Extralibs.nsi.mu"
+
+ghcNsiTemplate :: FilePath
+ghcNsiTemplate = winTemplates </> "GHC.nsi.mu"
+
 
 nsisInstDatTmpl :: FilePath
 nsisInstDatTmpl = winTemplates </> "inst.dat.mu"
 
 nsisUninstDatTmpl :: FilePath
 nsisUninstDatTmpl = winTemplates </> "uninst.dat.mu"
+
 
 -- | Some scripts and unchanging data files needed for the installer
 winInstExtrasFiles :: [FilePath]
@@ -164,5 +239,14 @@ winGhcTargetPackageDbDir = winTargetDir </> winGhcPackageDbDir
 
 -- | Additional build targets needed for the Windows version of HP
 winNeeds :: [FilePath]
-winNeeds = [ nsisFile, nsisInstDat, nsisUninstDat ]
+winNeeds = [ nsisFile,
+             msysNsisFile, msysNsisInstDat, msysNsisUninstDat,
+             ghcNsisFile,  ghcNsisInstDat,  ghcNsisUninstDat
+           ]
            ++ winInstExtras
+
+-- | Additional build targets needed for the Windows version of full HP
+--  (note however, that alex and happy live here, so we always need these)
+winExtraNeeds :: [FilePath]
+winExtraNeeds = [
+    extralibsNsisFile, extralibsNsisInstDat, extralibsNsisUninstDat ]

--- a/hptool/src/OS/Win/WinRules.hs
+++ b/hptool/src/OS/Win/WinRules.hs
@@ -27,8 +27,7 @@ import Utils
 
 winRules :: Rules ()
 winRules = do
-    genNsisData
-    genNsisFile
+    genNsisFiles
     copyInstExtras
 
 winGhcInstall :: FilePath -> GhcInstallAction
@@ -77,11 +76,6 @@ copyWinTargetExtras bc = do
     -- copy cabal executable
     cabalFile <- askCabalExe
     copyFileAction (return ()) (takeDirectory cabalFile) (winHpTargetDir </> "bin") (takeFileName cabalFile)
-
-    -- copy stack executable
-    stackFile <- askStackExe
-    copyFileAction (return ()) (takeDirectory stackFile) (winHpTargetDir </> "bin") (takeFileName stackFile)
-
 
 
 -- | These files are needed when building the installer


### PR DESCRIPTION
1.  Windows only: delay adding targetDir dependencies 

* hptool/src/OS/Win.hs
* Move the enumeration of the targetDir contents until
after we are actually complete with this directory.  This
step needs to be timed differently than the other builds
since on the Windows builds, HP and GHC are installed
into a single directory.  Without this, Shake will
complain that the directory contents of targetDir have
changed (upon populating targetDir with the HP-specific
packages) since the time of making a dependency on them
(which would happen after GHC is placed in targetDir).

2. Work around 2GB payload limit of NSIS 

The installer framework currently used for HP (the open
source project NSIS) uses a 32-bit-centric file format
(apparently) and thus has a limitation of 2GB as the maximum
size of a blob that can be included.  After investigating
numerous alternatives, the simplest work-around seemed to be
just to bundle and silently install a number of child
installers, breaking the actual HP payload into three
logical components: GHC, MSys, Stack, and the HP-specific
pre-built packages.

Three additional installer scripts are added here, to build 3
of the new child-installers (stack is already packaged with
its own NSIS installer, so that is happily used unmodified),
along with the necessarily bookkeeping to populate an NSI
file from a template, and shake rules to build these
installers at the right time with needed contents.  Further,
the original NSI file is modified to add some new UI (for
stack) and create the NSI install-time actions to launch the
new child-installers as necessary.

* hptool/os-extras/win/templates/Extralibs.nsi.mu
  * New. Template (using the "Mustache" syntax) for the
    additional pre-built HP-installed packages.
* hptool/os-extras/win/templates/GHC.nsi.mu
  * New. Template (using the "Mustache" syntax) for
    everything that is part of the GHC pre-built binary
    distribution.
* hptool/os-extras/win/templates/MSys.nsi.mu
  * New. Template (using the "Mustache" syntax) for the
    MSys content.
* hptool/os-extras/win/templates/Nsisfile.nsi.mu
  * In addition to the changes already mentioned above, some
    white space clean up to make it easy to read.  Add a
    public-service annoucement at the end of the installation
    to explain to users that they may see a brief "pop-up"
    window immediately after closing the installer (it is ghc
    running to update the package spec; this action is not
    new but the PSA is).
* hptool/src/OS/Win.hs
  * Build rules for the new sub-installers
* hptool/src/OS/Win/WinNsis.hs
  * The rules for building the NSI file from the template
* hptool/src/OS/Win/WinPaths.hs
  * Paths for all the new sub-installer templates, output
    files, etc.
* hptool/src/OS/Win/WinRules.hs
  * Replace the rule invocations for the NSIS
    generation. For stack, the linux-ish platforms simply
    copy the stack executable but for Windows, there is an
    installer and it is launched as part of the HP install,
    so remove the action here to copy the stack executable.

3.  Two dependencies for building hptool on Windows 

* hptool/hptool.cabal
  * Add filepath and unix-compat
