### PR TITLE
Improve silent install functionality (Windows)

### DIFF
--- a/hptool/src/OS/Win/WinNsis.hs
+++ b/hptool/src/OS/Win/WinNsis.hs
@@ -130,7 +130,7 @@ genNsisFiles = do
         mainSize <- getDirContentSize filterEmptyDirs winTargetDir
         let nsisCtx = expandNsisInfo rls bc ift
             ctx = nsisCtx `ctxAppend` pCtx
-            stackSize = 37 * 1024 * 1024 -- not sure how to actually determine
+            stackSize = 48 * 1024 * 1024 -- not sure how to automatically determine
             ift = InfoForTemplate pFile nFile stackFile stackSize mainSize
         copyExpandedFile ctx templ nFile
 


### PR DESCRIPTION
Add a command line option to the HP installer executable so
that an installation path for stack can be specified.
Previously, an installation path could be specified for the
Haskell Platform (ghc, et al), but not for stack (and stack's
location cannot be inferred from the HP default location).
With this change, both the HP components and stack can be
silently installed to separate, user-specified locations.

* hptool/os-extras/win/templates/Nsisfile.nsi.mu
  * Add support for a command-line option to the installer to
    allow a parameter, "/STACK=", to specify the installation
    path for stack
  * Improve the silent-install behavior for 64-bit versus
    32-bit installations
* hptool/src/OS/Win/WinNsis.hs
  * Update the size of the installed stack package