### PR TITLE
Result file (exe, pkg, etc.): "minimal" -> "core"

### DIFF
--- a/hptool/src/Main.hs
+++ b/hptool/src/Main.hs
@@ -33,7 +33,7 @@ flags = [ Option ['i'] ["info"] (NoArg $ Right Info)
         , Option [] ["prefix"] (ReqArg (Right . Prefix) "DIR")
                      "Set installation prefix (only for Posix builds)"
         , Option ['f'] ["full"] (NoArg $ Right Full)
-                     "Do a full (rather than minimal) build of the platform."
+                     "Do a full (rather than core) build of the platform."
         ]
 
 main :: IO ()
@@ -67,7 +67,7 @@ main = hSetEncoding stdout utf8 >> shakeArgsWith opts flags main'
                  \    build-package-<pkg> -- build the package (name or name-ver)\n\
                  \    build-local         -- build the local GHC environment\n\
                  \    build-website       -- build the website\n\
-                 \  and opts may be 'f' for a full rather than minimal build, 'i' for info\n\
+                 \  and opts may be 'f' for a full rather than core build, 'i' for info\n\
                  \  or 'prefix=...' to set a custom install location prefix for linux"
         return Nothing
 
@@ -94,7 +94,7 @@ main = hSetEncoding stdout utf8 >> shakeArgsWith opts flags main'
 
 
 whatIsIncluded :: Release -> [String]
-whatIsIncluded rel = ("-- Minimal Platform:":minimalIncludes) ++ ("-- Full Platform:":fullIncludes) where
+whatIsIncluded rel = ("-- Core Platform:":minimalIncludes) ++ ("-- Full Platform:":fullIncludes) where
     minimalIncludes = map (concat . includeToString) $ relMinimalIncludes rel
     fullIncludes    = map (concat . includeToString) $ relIncludes rel where
     includeToString (IncGHC, p)      = "GHC:    " : [show p]

--- a/hptool/src/OS/Mac.hs
+++ b/hptool/src/OS/Mac.hs
@@ -80,7 +80,7 @@ macOsFromConfig BuildConfig{..} = OS{..}
             copyFile' f $ hpDocDir </> takeFileName f
 
     productName =
-        "Haskell Platform " ++ showVersion hpVersion ++ (if bcIncludeExtra then " Full" else " Minimal") ++ archBits bcArch
+        "Haskell Platform " ++ showVersion hpVersion ++ (if bcIncludeExtra then " Full" else " Core") ++ archBits bcArch
 
     osProduct = productDir </> productName <.> "pkg"
     signedProduct = productDir </> (productName ++ "-signed") <.> "pkg"
@@ -144,7 +144,7 @@ macOsFromConfig BuildConfig{..} = OS{..}
             command_ []
                 "pkgbuild"
                 [ "--identifier", "org.haskell.HaskellPlatform.Libraries."
-                                  ++ hpPkgMajorVer ++ (if bcIncludeExtra then "-full" else "-minimal") ++ ".pkg"
+                                  ++ hpPkgMajorVer ++ (if bcIncludeExtra then "-full" else "-core") ++ ".pkg"
                 , "--version", hpPkgMinorVer
                 , "--install-location", "/Library/Haskell"
                 , "--root", "build/target/Library/Haskell"
@@ -157,7 +157,7 @@ macOsFromConfig BuildConfig{..} = OS{..}
             command_ []
                 "productbuild"
                 [ "--identifier", "org.haskell.HaskellPlatform."
-                                  ++ hpPkgMajorVer ++ (if bcIncludeExtra then "-full" else "-minimal") ++ ".pkg"
+                                  ++ hpPkgMajorVer ++ (if bcIncludeExtra then "-full" else "-core") ++ ".pkg"
                 , "--version", hpPkgMinorVer
                 , "--resources", osxInstallResources
                 , "--distribution", osxInstallerDist

--- a/hptool/src/OS/Posix.hs
+++ b/hptool/src/OS/Posix.hs
@@ -72,7 +72,7 @@ posixOS BuildConfig{..} = OS{..}
     installScript = extrasDir </> "installer" </> "install-haskell-platform.sh"
 
     productName =
-        "haskell-platform-" ++ showVersion hpVersion ++ "-unknown-posix-" ++ (if bcIncludeExtra then "-full-" else "-minimal-") ++ bcArch
+        "haskell-platform-" ++ showVersion hpVersion ++ "-unknown-posix-" ++ (if bcIncludeExtra then "-full-" else "-core-") ++ bcArch
 
     genericExtrasSrc = "hptool/os-extras/posix"
 

--- a/hptool/src/OS/Win/WinNsis.hs
+++ b/hptool/src/OS/Win/WinNsis.hs
@@ -65,7 +65,7 @@ genNsisFiles = do
     -- we need to filter those paths out as they are covered by the
     -- msys and extralibs .dat lists.  N.b.: Filtering by names could be
     -- fragile in light of any directory, package, structuring changes.
-    -- Also note that even in for the "minimal" HP build, there are still
+    -- Also note that even in for the "core" HP build, there are still
     -- a few things in extralibs (specifically alex and happy, as well as
     -- the cabal executable.)
     ghcInstFilter = filterEmptyDirs . skipExtralibs . skipMSys

--- a/hptool/src/OS/Win/WinPaths.hs
+++ b/hptool/src/OS/Win/WinPaths.hs
@@ -223,7 +223,7 @@ winDocTargetDir = winTargetDir </> "doc"
 winProductFileName :: Bool -> Version -> String -> FilePath
 winProductFileName isFull hpv arch =
     ("HaskellPlatform-" ++ versionAndArch ++ "-setup") <.> "exe"
-  where versionAndArch = showVersion hpv ++ (if isFull then "-full" else "-minimal") ++ '-' : arch
+  where versionAndArch = showVersion hpv ++ (if isFull then "-full" else "-core") ++ '-' : arch
 
 -- | Directory where the installer file is built.
 winProductFile :: Bool -> Version -> String -> FilePath

--- a/hptool/src/Package.hs
+++ b/hptool/src/Package.hs
@@ -64,7 +64,7 @@ packageRules = do
             -- Having the package names reverse sort as graph keys makes the SCC
             -- components come out closer to normal sort order. Go figure!
 
---TODO choose proper "allPackages" based on minimal or full build
+--TODO choose proper "allPackages" based on core or full build
 
 installAction :: FilePath -> Bool -> Release -> Action ()
 installAction depFile incExtras hpRel = do

--- a/hptool/src/PlatformDB.hs
+++ b/hptool/src/PlatformDB.hs
@@ -18,15 +18,15 @@ import Data.List (partition)
 import Types
 import Utils (version)
 
--- | both minimal and extra platform includes
+-- | both core and extra platform includes
 allRelIncludes :: Release -> [Include]
 allRelIncludes r = relMinimalIncludes r ++ relIncludes r
 
--- | Construct a release with a minimal partition
+-- | Construct a release with a core partition
 releaseWithMinimal :: String -> [Include] -> [Include] -> Release
 releaseWithMinimal vstr minimalIncs incs = Release (HpVersion $ version vstr) minimalIncs incs
 
--- | Construct a release, when there is not a seperate minimal selection of includes with the main ones.
+-- | Construct a release, when there is not a seperate core selection of includes with the main ones.
 release :: String -> [Include] -> Release
 release vstr incs = Release (HpVersion $ version vstr) incs []
 


### PR DESCRIPTION
Fixes haskell-platform issue #282 with the obvious edits for all platforms
(including hptool error or help messages, and code comments).

* hptool/src/Main.hs
* hptool/src/OS/Mac.hs
* hptool/src/OS/Posix.hs
* hptool/src/OS/Win/WinNsis.hs
* hptool/src/OS/Win/WinPaths.hs
* hptool/src/Package.hs
* hptool/src/PlatformDB.hs