### PR TITLE
Put upper version bound on shake

### DIFF
--- a/hptool/hptool.cabal
+++ b/hptool/hptool.cabal
@@ -55,7 +55,7 @@ Executable hptool
     containers,
     directory,
     hastache >=0.6.0,
-    shake >= 0.14,
+    shake >= 0.14 && < 0.16,
     split,
     text,
     transformers,


### PR DESCRIPTION
As a temporary measure, put an upper version bound on the shake package to avoid the changes in shake 0.16 which break the hptool build.  We can remove this when we have time to do the updates needed.