### PR TITLE
Update core packages' versions for 8.2.2; plus minor things 

### DIFF
--- a/hptool/hptool.cabal
+++ b/hptool/hptool.cabal
@@ -18,7 +18,6 @@ Executable hptool
     GhcDist,
     HaddockMaster,
     LocalCommand,
-    Main,
     OS,
     OS.Internal,
     OS.Mac,

--- a/hptool/src/Main.hs
+++ b/hptool/src/Main.hs
@@ -88,7 +88,7 @@ main = hSetEncoding stdout utf8 >> shakeArgsWith opts flags main'
 
     opts = shakeOptions
 
-    hpRelease = hp_8_2_1
+    hpRelease = hp_8_2_2
     hpFullName = show $ relVersion hpRelease
     srcTarFile = productDir </> hpFullName <.> "tar.gz"
 

--- a/hptool/src/OS/Win.hs
+++ b/hptool/src/OS/Win.hs
@@ -15,6 +15,9 @@ import Development.Shake.FilePath
 import qualified Distribution.InstalledPackageInfo as C
 #endif
 import qualified Distribution.Package as C
+#if MIN_VERSION_Cabal(2,0,0)
+import qualified Distribution.Text as C ( display )
+#endif
 
 import Dirs
 import LocalCommand
@@ -26,7 +29,10 @@ import Paths
 import Types
 import Utils
 
-#if MIN_VERSION_Cabal(1,24,0)
+#if MIN_VERSION_Cabal(2,0,0)
+getPkgId :: C.HasUnitId pkg => pkg -> String
+getPkgId pkg = C.display $ C.installedUnitId pkg
+#elif MIN_VERSION_Cabal(1,24,0)
 getPkgId :: C.HasUnitId pkg => pkg -> String
 getPkgId pkg = case C.installedUnitId pkg of
   C.SimpleUnitId (C.ComponentId s) -> s

--- a/hptool/src/Releases2015.hs
+++ b/hptool/src/Releases2015.hs
@@ -111,7 +111,7 @@ hp_7_10_2 =
 
 hp_7_10_2_a :: Release
 hp_7_10_2_a =
-    release "7.10.2-a" $ deltaFrom hp_7_10_2
+    release "7.10.2-a" $ deltaFrom' hp_7_10_2
         [ incLib "text"                     "1.2.1.3"
         , incLib "fgl"                      "5.5.2.1"
         ]

--- a/hptool/src/Releases2017.hs
+++ b/hptool/src/Releases2017.hs
@@ -4,7 +4,7 @@ import PlatformDB
 import Types
 
 releases2017 :: [Release]
-releases2017 = [hp_8_2_1]
+releases2017 = [hp_8_2_1, hp_8_2_2]
 
 
 hp_8_2_1 :: Release
@@ -110,3 +110,16 @@ hp_8_2_1 =
         ]
 
 -- TO add: binary? semigroups? regexlib? safe? tagsoup? tagged? tasty? optparse-applicative? clock? criterion? reflection?
+
+hp_8_2_2 :: Release
+hp_8_2_2 =
+    (uncurry $ releaseWithMinimal "8.2.2") $ deltaFrom hp_8_2_1
+        [ incGHC                            "8.2.2"
+        , incGHCLib "Cabal"                 "2.0.1.0"
+        , incGHCLib "base"                  "4.10.1.0"
+        {- These packages are in the GHC distribution, and hence bundled with
+        the Platform. However, they are not officially part of the Platform,
+        and as such, do not carry the same stability guaruntees.
+        , incGHCLib "ghc-prim"              "0.5.1.1"
+        -}
+        ]


### PR DESCRIPTION
* Update core packages' versions for 8.2.2
  * This is the minimal update to the version numbers of the
included packages, matching the core packages with what
ghc 8.2.2 was built with.  Changes to the includes
for the full build are still under review.
* Resolve cabal warning about Main in 'other-modules'
* Update to work with Cabal >= 2.0.0