### PR TITLE
Update caskroom link

### DIFF
--- a/website/templates/new-site/download-os-sections.html.mu
+++ b/website/templates/new-site/download-os-sections.html.mu
@@ -129,7 +129,7 @@
                             <div id="osx-homebrewcask" class="flavor">
                                 <h3>Homebrew Cask</h3>
                                 <p>To install Haskell Platform with
-                                    <a href="http://caskroom.io">Homebrew Cask</a>,
+                                    <a href="http://caskroom.github.io">Homebrew Cask</a>,
                                     simply run,
                                 </p>
                                 <pre>$ brew cask install haskell-platform</pre>

--- a/website/templates/plan-a/download-os-sections.html.mu
+++ b/website/templates/plan-a/download-os-sections.html.mu
@@ -142,7 +142,7 @@
                             <div id="osx-homebrewcask" class="flavor">
                                 <h3>Homebrew Cask</h3>
                                 <p>To install Haskell Platform with
-                                    <a href="http://caskroom.io">Homebrew Cask</a>,
+                                    <a href="http://caskroom.github.io">Homebrew Cask</a>,
                                     simply run,
                                 </p>
                                 <pre>$ brew cask install haskell-platform</pre>


### PR DESCRIPTION
caskroom.io doesn't seem to be anything useful (maybe someone's domain ownership lapsed or something).