### PR TITLE
Fix #288: Upgrade hptool for shake version 0.16

### DIFF
--- a/hptool/hptool.cabal
+++ b/hptool/hptool.cabal
@@ -55,7 +55,7 @@ Executable hptool
     containers,
     directory,
     hastache >=0.6.0,
-    shake >= 0.14 && < 0.16,
+    shake >= 0.16,
     split,
     text,
     transformers,


### PR DESCRIPTION
This is just @randen's patch from #288, rebased against haskell-platform 8.6.3.

I ran into this problem when upgrading GHC this morning, because shake 0.15 doesn't build with GHC 8.6 any more.