### PR TITLE
Removed the homebrew section from the installation page.

### DIFF
--- a/website/templates/new-site/download-os-sections.html.mu
+++ b/website/templates/new-site/download-os-sections.html.mu
@@ -52,16 +52,6 @@
 				  to install stack.
                             </p>
                             </div>
-
-                            <div id="osx-homebrewcask" class="flavor">
-                                <h3>Homebrew Cask</h3>
-                                <p>To install Haskell Platform with
-                                    <a href="http://caskroom.io">Homebrew Cask</a>,
-                                    simply run,
-                                </p>
-                                <pre>$ brew cask install haskell-platform</pre>
-                            </div> <!-- #osx-homebrewcask -->
-
                         </div>
                         <div class="bottom-rule"></div>
                     </section>


### PR DESCRIPTION
When you visit the download page on macOS with noscript enabled, an extra section of the instructions pops up with a `brew` command that doesn't work:
<img width="559" alt="Screen Shot 2020-04-24 at 9 28 34 PM" src="https://user-images.githubusercontent.com/624310/80271439-ff8d4c80-8674-11ea-9b95-e2f4f6ff8213.png">

When you run the command, you get the following output:

```
Error: Cask 'haskell-platform' is unavailable: No Cask with this name exists.
```

I ran into this problem when I was helping somebody install Haskell and they got confused. This problem didn't happen on my machine because I had JS enabled. Having this section seems unnecessary and could lead to confusion, so this PR removes the section from the download page HTML template. I'm not sure if I need to change any other files along with this change.

For reference, this is what the page looks like with JS *enabled*, even without this PR. The section with the `brew` command is present in the HTML but invisible.
<img width="1165" alt="Screen Shot 2020-04-24 at 9 27 36 PM" src="https://user-images.githubusercontent.com/624310/80271518-af62ba00-8675-11ea-9583-15cb337574ed.png">
