### PR TITLE
Mention that Haskell Platform is no longer the recommended way to install Haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 Haskell Platform
 ----------------
 
+"I WANT TO INSTALL HASKELL"
+---------------------------
+
+The Haskell Platform is deprecated and no longer the recommended way
+to install Haskell.  The recommended way is to follow the instructions on
+[the Haskell.org Downloads page](https://www.haskell.org/downloads/).
+
 OVERVIEW
 --------
 "Haskell Platform" is a combination of the GHC compiler and core libraries,


### PR DESCRIPTION
Old Haskell resources still mention "Haskell Platform" as the way to install Haskell. It seems to be confusing when they search for "Haskell Platform" and just end up at the new downloads page. We have [an issue](https://github.com/haskell-infra/www.haskell.org/issues/164) to mitigate that on the Haskell.org side.

On the other hand, some searches end up at this Github repository, for example see 
[a recent user report](https://i.reddit.com/r/learnprogramming/comments/sgvk35/is_haskell_platform_no_longer_supported/huyweun/.compact). Perhaps we could short circuit their confusing by mentioning prominently in the README that the Platform is no longer supported, and linking them to the downloads page instead.